### PR TITLE
Kubernetes networks

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -31,6 +31,12 @@ spec:
            - /homework/index.html
          initialDelaySeconds: 5
          periodSeconds: 5
+       readinessProbe:
+         httpGet:
+           path: /index.html
+           port: 8000
+         initialDelaySeconds: 5
+         periodSeconds: 5
        lifecycle:
          preStop:
            exec:

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -20,6 +20,7 @@ spec:
       labels:
         app: nginx
     spec:
+     serviceAccountName: monitoring
      containers:
      - name: nginx
        image: nginx:latest

--- a/ingress.yaml
+++ b/ingress.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress
+  namespace: homework
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+spec:
+  rules:
+    - host: homework.otus
+      http:
+        paths:
+          - path: /homepage(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: my-service
+                port:
+                  number: 80

--- a/kubernetes-networks/configmap.yaml
+++ b/kubernetes-networks/configmap.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-conf
+  namespace: homework
+data:
+  nginx.conf: |
+    server {
+        listen 8000;
+        server_name _;
+        location / {
+            try_files $uri $uri/ /index.html;
+            root /homework;
+            index  index.html index.htm;
+        }
+     }

--- a/kubernetes-networks/deployment.yaml
+++ b/kubernetes-networks/deployment.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  namespace: homework
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+     serviceAccountName: monitoring
+     containers:
+     - name: nginx
+       image: nginx:latest
+       livenessProbe:
+         exec:
+           command:
+           - cat
+           - /homework/index.html
+         initialDelaySeconds: 5
+         periodSeconds: 5
+       readinessProbe:
+         httpGet:
+           path: /index.html
+           port: 8000
+         initialDelaySeconds: 5
+         periodSeconds: 5
+       lifecycle:
+         preStop:
+           exec:
+             command: ["/bin/sh","-c","rm -rf /homework/index.html"]
+       ports:
+       - containerPort: 8000
+       volumeMounts:
+       - name: workdir
+         mountPath: /homework
+       - name: nginx-conf
+         mountPath: /etc/nginx/conf.d/default.conf
+         subPath: nginx.conf
+  # These containers are run during pod initialization
+     initContainers:
+     - name: init-demo
+       image: busybox:1.28
+       command:
+       - wget
+       - "-O"
+       - "/init/index.html"
+       - http://info.cern.ch
+       volumeMounts:
+       - name: workdir
+         mountPath: "/init"
+     dnsPolicy: Default
+     volumes:
+     - name: workdir
+       emptyDir: {}
+     - name: nginx-conf
+       configMap:
+         name: nginx-conf
+     nodeSelector:
+       homework: "true"

--- a/kubernetes-networks/ingress.yaml
+++ b/kubernetes-networks/ingress.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress
+  namespace: homework
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+spec:
+  rules:
+    - host: homework.otus
+      http:
+        paths:
+          - path: /homepage(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: my-service
+                port:
+                  number: 80

--- a/kubernetes-networks/namespace.yaml
+++ b/kubernetes-networks/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homework
+  labels:
+    name: homework

--- a/kubernetes-networks/pod.yaml
+++ b/kubernetes-networks/pod.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+  namespace: homework
+spec:
+  containers:
+  - name: nginx
+    image: nginx:latest
+    lifecycle:
+      preStop:
+        exec:
+          command: ["/bin/sh","-c","rm -rf /homework/index.html"]
+    ports:
+    - containerPort: 8000
+    volumeMounts:
+    - name: workdir
+      mountPath: /homework
+    - name: nginx-conf
+      mountPath: /etc/nginx/conf.d/default.conf
+      subPath: nginx.conf
+  # These containers are run during pod initialization
+  initContainers:
+  - name: init-demo
+    image: busybox:1.28
+    command:
+    - wget
+    - "-O"
+    - "/init/index.html"
+    - http://info.cern.ch
+    volumeMounts:
+    - name: workdir
+      mountPath: "/init"
+  dnsPolicy: Default
+  volumes:
+  - name: workdir
+    emptyDir: {}
+  - name: nginx-conf
+    configMap:
+      name: nginx-conf

--- a/kubernetes-networks/service.yaml
+++ b/kubernetes-networks/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service
+  namespace: homework
+spec:
+  type: ClusterIP
+  selector:
+    app:  nginx
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/service.yaml
+++ b/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service
+  namespace: homework
+spec:
+  type: ClusterIP
+  selector:
+    app:  nginx
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000


### PR DESCRIPTION
# Выполнено ДЗ №3

 - [ ] Основное ДЗ

● Изменить readiness-пробу в манифесте deployment.yaml из
прошлого ДЗ на httpGet, вызывающую URL /index.html
● Необходимо создать манифест service.yaml, описывающий сервис
типа ClusterIP, который будет направлять трафик на поды,
управляемые вашим deployment
● Установить в кластер ingress-контроллер nginx
● Создать манифест ingress.yaml, в котором будет описан объект
типа ingress, направляющий все http запросы к хосту
homework.otus на ранее созданный сервис. В результате запрос
http://homework.otus/index.html должен отдавать код html
страницы, находящейся в подах
 - [ ] Задание со *
Доработать манифест ingress.yaml, описав в нем rewrite-правила
так, чтобы обращение по адресу http://homework.otus/index.html
форвардилось на http://homework.otus/homepage
## В процессе сделано:
 - Пункт 1
 в deployment   внесены изменения  добавлена rreadiness проба
 - Пункт 2
 создан фаил service.yaml 
- Пункт 3
включен  ingress  контроллер 
minikube addons enable ingress
- Пункт 4
создан фаил  ingress.yaml 
- Пункт 5
узнать minikube  ip   добавить запись в  /etc/hosts  192.168.49.2  homework.otus
- Пункт 6
включить туннель minikube tunnel

## Как запустить проект:
 - Например, запустить команду X в директории Y
 1)kubectl apply -f deployment.yaml обновляем конфигруацию  deployment
2)  далее  запускасем сервис Kubectl apply -f service.yaml
3)  запускаем  ingress  kubectl apply -f ingress.yaml



## Как проверить работоспособность:
curl -I -k http://homework.otus/homepage должен отдать страницу index.html 

## PR checklist:
 - [ ] Выставлен label с темой домашнего задания
