### PR TITLE
Kubernetes volumes

### DIFF
--- a/cm.yaml
+++ b/cm.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: random-cm
+  namespace: homework
+data:
+  file: |
+    name:  Maksim
+    number: "8926820"

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -20,6 +20,7 @@ spec:
       labels:
         app: nginx
     spec:
+     serviceAccountName: monitoring
      containers:
      - name: nginx
        image: nginx:latest
@@ -28,6 +29,12 @@ spec:
            command:
            - cat
            - /homework/index.html
+         initialDelaySeconds: 5
+         periodSeconds: 5
+       readinessProbe:
+         httpGet:
+           path: /index.html
+           port: 8000
          initialDelaySeconds: 5
          periodSeconds: 5
        lifecycle:
@@ -42,7 +49,9 @@ spec:
        - name: nginx-conf
          mountPath: /etc/nginx/conf.d/default.conf
          subPath: nginx.conf
-  # These containers are run during pod initialization
+       - name: random-cm
+         mountPath: /homework/conf/file
+         subPath: file
      initContainers:
      - name: init-demo
        image: busybox:1.28
@@ -57,9 +66,14 @@ spec:
      dnsPolicy: Default
      volumes:
      - name: workdir
-       emptyDir: {}
+       persistentVolumeClaim:
+         claimName:  nginx-pvc
      - name: nginx-conf
        configMap:
          name: nginx-conf
+     - name: random-cm
+       configMap:
+         name: random-cm
      nodeSelector:
        homework: "true"
+

--- a/pv.yaml
+++ b/pv.yaml
@@ -1,0 +1,10 @@
+kind: PersistentVolume
+metadata:
+  name: nginx-pv
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path:  /workdir

--- a/pvc.yaml
+++ b/pvc.yaml
@@ -1,0 +1,12 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: nginx-pvc
+  namespace: homework
+spec:
+  storageClassName: deploy-class
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/storageclass.yaml
+++ b/storageclass.yaml
@@ -1,0 +1,9 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name:  deploy-class
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "false"
+provisioner: k8s.io/minikube-hostpath
+reclaimPolicy: Retain
+volumeBindingMode: Immediate


### PR DESCRIPTION
# Выполнено ДЗ №4

 - [ ] Основное ДЗ
 Создать манифест pvc.yaml, описывающий
PersistentVolumeClaim, запрашивающий хранилище с
storageClass по-умолчанию
● Создать манифест cm.yaml для объекта типа configMap,
описывающий произвольный набор пар ключ-значение
● В манифесте deployment.yaml изменить спецификацию
volume типа emptyDir, который монтируется в init и
основной контейнер, на pvc, созданный в предыдущем
пункте
● В манифесте deployment.yaml добавить монтирование
ранее созданного configMap как volume к основному
контейнеру пода в директорию /homework/conf, так, чтобы
его содержимое можно было получить, обратившись по url
/conf/file
- [ ] Задание со *
 Создать манифест storageClass.yaml описывающий объект
типа storageClass с provisioner
https://k8s.io/minikube-hostpath и reclaimPolicy Retain
● Изменить манифест pvc.yaml так, чтобы в нем
запрашивалось хранилище созданного вами storageClass-а

## В процессе сделано:
 - Пункт 1
 создан pv + pvc  запрашивающие хранилище в storageclass  по умолчанию 
- Пункт 2
создан configmap cm.yaml
- Пункт 3
внесены изменения в deployment.yaml для монтирования pvc и configmap
- Пункт 4
- создан storageclass и  внесены изменения в pvc.yaml предварительно прошлый pvc и pv  с подами удален

## Как запустить проект:
1.запускаем pv и pvc, наблюдаем за изменением статуса bound
kubectl apply -f pv. yaml 
kubectl apply -f pvc.yaml
2.  далее запускаем configmap
kubectl apply -f cm.yaml
3.   далее запускаем deployment.yaml
kubectl apply  -f deploymetn.yaml
4. Создаем storageclass
kubectl apply -f storageclass.yaml
5. Далее scale  поды в 0 и удаляем созданную в пролшлый раз  pvc
 kubectl scale --replicas=0 -f deployment.yaml
 kubectl delete pvc nginx-pvc  -n homework 
kubectl delete pv nginx-pv
6.  Вновь применяем уже новую pvc  и scale  снова в 3 пода 
kubectl apply -f    pvc.yaml   (разница между файлами  добавил storageclass: name)
kubectl scale --replicas=3 -f deployment.yaml
## Как проверить работоспособность:
 - Например, перейти по ссылке http://localhost:8080
 kubectl get pvc -A  
Должна быть создана pvc с нужным storageclass: deploy-class
провалится в под 
kubectl  exec -it  -n homework    "название пода"  -- /bin/bash
и проверить  что есть директория /homework
 и проверить  configmap  внутри пода 
cat /homework/conf/file

## PR checklist:
 - [ ] Выставлен label с темой домашнего задания
