### PR TITLE
Kubernetes logging

### DIFF
--- a/kubernetes-logging/grafana_values.yaml
+++ b/kubernetes-logging/grafana_values.yaml
@@ -1,0 +1,1335 @@
+global:
+  # -- Overrides the Docker registry globally for all images
+  imageRegistry: null
+
+  # To help compatibility with other charts which use global.imagePullSecrets.
+  # Allow either an array of {name: pullSecret} maps (k8s-style), or an array of strings (more common helm-style).
+  # Can be tempalted.
+  # global:
+  #   imagePullSecrets:
+  #   - name: pullSecret1
+  #   - name: pullSecret2
+  # or
+  # global:
+  #   imagePullSecrets:
+  #   - pullSecret1
+  #   - pullSecret2
+  imagePullSecrets: []
+
+rbac:
+  create: true
+  ## Use an existing ClusterRole/Role (depending on rbac.namespaced false/true)
+  # useExistingRole: name-of-some-role
+  # useExistingClusterRole: name-of-some-clusterRole
+  pspEnabled: false
+  pspUseAppArmor: false
+  namespaced: false
+  extraRoleRules: []
+  # - apiGroups: []
+  #   resources: []
+  #   verbs: []
+  extraClusterRoleRules: []
+  # - apiGroups: []
+  #   resources: []
+  #   verbs: []
+serviceAccount:
+  create: true
+  name:
+  nameTest:
+  ## ServiceAccount labels.
+  labels: {}
+  ## Service account annotations. Can be templated.
+  #  annotations:
+  #    eks.amazonaws.com/role-arn: arn:aws:iam::123456789000:role/iam-role-name-here
+
+  ## autoMount is deprecated in favor of automountServiceAccountToken
+  # autoMount: false
+  automountServiceAccountToken: false
+
+replicas: 1
+
+## Create a headless service for the deployment
+headlessService: false
+
+## Should the service account be auto mounted on the pod
+automountServiceAccountToken: true
+
+## Create HorizontalPodAutoscaler object for deployment type
+#
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPU: "60"
+  targetMemory: ""
+  behavior: {}
+
+## See `kubectl explain poddisruptionbudget.spec` for more
+## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+podDisruptionBudget: {}
+#  apiVersion: ""
+#  minAvailable: 1
+#  maxUnavailable: 1
+
+## See `kubectl explain deployment.spec.strategy` for more
+## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+deploymentStrategy:
+  type: RollingUpdate
+
+readinessProbe:
+  httpGet:
+    path: /api/health
+    port: 3000
+
+livenessProbe:
+  httpGet:
+    path: /api/health
+    port: 3000
+  initialDelaySeconds: 60
+  timeoutSeconds: 30
+  failureThreshold: 10
+
+## Use an alternate scheduler, e.g. "stork".
+## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+##
+# schedulerName: "default-scheduler"
+
+image:
+  # -- The Docker registry
+  registry: docker.io
+  # -- Docker image repository
+  repository: grafana/grafana
+  # Overrides the Grafana image tag whose default is the chart appVersion
+  tag: 8.5.3
+  sha: ""
+  pullPolicy: IfNotPresent
+
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ## Can be templated.
+  ##
+  pullSecrets: []
+  #   - myRegistrKeySecretName
+
+testFramework:
+  enabled: true
+  image:
+    # -- The Docker registry
+    registry: docker.io
+    repository: bats/bats
+    tag: "v1.4.1"
+  imagePullPolicy: IfNotPresent
+  securityContext: {}
+  resources: {}
+  #  limits:
+  #    cpu: 100m
+  #    memory: 128Mi
+  #  requests:
+  #    cpu: 100m
+  #    memory: 128Mi
+
+# dns configuration for pod
+dnsPolicy: ~
+dnsConfig: {}
+  # nameservers:
+  #   - 8.8.8.8
+  #   options:
+  #   - name: ndots
+  #     value: "2"
+  #   - name: edns0
+
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 472
+  runAsGroup: 472
+  fsGroup: 472
+
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+    - ALL
+  seccompProfile:
+    type: RuntimeDefault
+
+# Enable creating the grafana configmap
+createConfigmap: true
+
+# Extra configmaps to mount in grafana pods
+# Values are templated.
+extraConfigmapMounts: []
+  # - name: certs-configmap
+  #   mountPath: /etc/grafana/ssl/
+  #   subPath: certificates.crt # (optional)
+  #   configMap: certs-configmap
+  #   readOnly: true
+
+
+extraEmptyDirMounts: []
+  # - name: provisioning-notifiers
+  #   mountPath: /etc/grafana/provisioning/notifiers
+
+
+# Apply extra labels to common labels.
+extraLabels: {}
+
+## Assign a PriorityClassName to pods if set
+# priorityClassName:
+
+downloadDashboardsImage:
+  # -- The Docker registry
+  registry: docker.io
+  repository: curlimages/curl
+  tag: 7.85.0
+  sha: ""
+  pullPolicy: IfNotPresent
+
+downloadDashboards:
+  env: {}
+  envFromSecret: ""
+  resources: {}
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
+    seccompProfile:
+      type: RuntimeDefault
+  envValueFrom: {}
+  #  ENV_NAME:
+  #    configMapKeyRef:
+  #      name: configmap-name
+  #      key: value_key
+
+## Pod Annotations
+# podAnnotations: {}
+
+## Pod Labels
+# podLabels: {}
+
+podPortName: grafana
+gossipPortName: gossip
+## Deployment annotations
+# annotations: {}
+
+## Expose the grafana service to be accessed from outside the cluster (LoadBalancer service).
+## or access it from within the cluster (ClusterIP service). Set the service type and the port to serve it.
+## ref: http://kubernetes.io/docs/user-guide/services/
+##
+service:
+  enabled: true
+  type: ClusterIP
+  loadBalancerIP: ""
+  loadBalancerClass: ""
+  loadBalancerSourceRanges: []
+  port: 80
+  targetPort: 3000
+    # targetPort: 4181 To be used with a proxy extraContainer
+  ## Service annotations. Can be templated.
+  annotations: {}
+  labels: {}
+  portName: service
+  # Adds the appProtocol field to the service. This allows to work with istio protocol selection. Ex: "http" or "tcp"
+  appProtocol: ""
+
+serviceMonitor:
+  ## If true, a ServiceMonitor CRD is created for a prometheus operator
+  ## https://github.com/coreos/prometheus-operator
+  ##
+  enabled: false
+  path: /metrics
+  #  namespace: monitoring  (defaults to use the namespace this chart is deployed to)
+  labels: {}
+  interval: 30s
+  scheme: http
+  tlsConfig: {}
+  scrapeTimeout: 30s
+  relabelings: []
+  metricRelabelings: []
+  targetLabels: []
+
+extraExposePorts: []
+ # - name: keycloak
+ #   port: 8080
+ #   targetPort: 8080
+
+# overrides pod.spec.hostAliases in the grafana deployment's pods
+hostAliases: []
+  # - ip: "1.2.3.4"
+  #   hostnames:
+  #     - "my.host.com"
+
+ingress:
+  enabled: false
+  # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
+  # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
+  # ingressClassName: nginx
+  # Values can be templated
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  labels: {}
+  path: /
+
+  # pathType is only for k8s >= 1.1=
+  pathType: Prefix
+
+  hosts:
+    - chart-example.local
+  ## Extra paths to prepend to every host configuration. This is useful when working with annotation based services.
+  extraPaths: []
+  # - path: /*
+  #   backend:
+  #     serviceName: ssl-redirect
+  #     servicePort: use-annotation
+  ## Or for k8s > 1.19
+  # - path: /*
+  #   pathType: Prefix
+  #   backend:
+  #     service:
+  #       name: ssl-redirect
+  #       port:
+  #         name: use-annotation
+
+
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+#  limits:
+#    cpu: 100m
+#    memory: 128Mi
+#  requests:
+#    cpu: 100m
+#    memory: 128Mi
+
+## Node labels for pod assignment
+## ref: https://kubernetes.io/docs/user-guide/node-selection/
+#
+nodeSelector:
+  node: infra
+
+## Tolerations for pod assignment
+## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+##
+tolerations:
+- effect: NoSchedule
+  key: node-role
+  operator: Equal
+  value: infra
+
+## Affinity for pod assignment (evaluated as template)
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+##
+affinity: {}
+
+## Topology Spread Constraints
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+##
+topologySpreadConstraints: []
+
+## Additional init containers (evaluated as template)
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+##
+extraInitContainers: []
+
+## Enable an Specify container in extraContainers. This is meant to allow adding an authentication proxy to a grafana pod
+extraContainers: ""
+# extraContainers: |
+# - name: proxy
+#   image: quay.io/gambol99/keycloak-proxy:latest
+#   args:
+#   - -provider=github
+#   - -client-id=
+#   - -client-secret=
+#   - -github-org=<ORG_NAME>
+#   - -email-domain=*
+#   - -cookie-secret=
+#   - -http-address=http://0.0.0.0:4181
+#   - -upstream-url=http://127.0.0.1:3000
+#   ports:
+#     - name: proxy-web
+#       containerPort: 4181
+
+## Volumes that can be used in init containers that will not be mounted to deployment pods
+extraContainerVolumes: []
+#  - name: volume-from-secret
+#    secret:
+#      secretName: secret-to-mount
+#  - name: empty-dir-volume
+#    emptyDir: {}
+
+## Enable persistence using Persistent Volume Claims
+## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+##
+persistence:
+  type: pvc
+  enabled: false
+  # storageClassName: default
+  accessModes:
+    - ReadWriteOnce
+  size: 10Gi
+  # annotations: {}
+  finalizers:
+    - kubernetes.io/pvc-protection
+  # selectorLabels: {}
+  ## Sub-directory of the PV to mount. Can be templated.
+  # subPath: ""
+  ## Name of an existing PVC. Can be templated.
+  # existingClaim:
+  ## Extra labels to apply to a PVC.
+  extraPvcLabels: {}
+
+  ## If persistence is not enabled, this allows to mount the
+  ## local storage in-memory to improve performance
+  ##
+  inMemory:
+    enabled: false
+    ## The maximum usage on memory medium EmptyDir would be
+    ## the minimum value between the SizeLimit specified
+    ## here and the sum of memory limits of all containers in a pod
+    ##
+    # sizeLimit: 300Mi
+
+initChownData:
+  ## If false, data ownership will not be reset at startup
+  ## This allows the grafana-server to be run with an arbitrary user
+  ##
+  enabled: true
+
+  ## initChownData container image
+  ##
+  image:
+    # -- The Docker registry
+    registry: docker.io
+    repository: library/busybox
+    tag: "1.31.1"
+    sha: ""
+    pullPolicy: IfNotPresent
+
+  ## initChownData resource requests and limits
+  ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources: {}
+  #  limits:
+  #    cpu: 100m
+  #    memory: 128Mi
+  #  requests:
+  #    cpu: 100m
+  #    memory: 128Mi
+  securityContext:
+    runAsNonRoot: false
+    runAsUser: 0
+    seccompProfile:
+      type: RuntimeDefault
+    capabilities:
+      add:
+        - CHOWN
+
+# Administrator credentials when not using an existing secret (see below)
+adminUser: admin
+# adminPassword: strongpassword
+
+# Use an existing secret for the admin user.
+admin:
+  ## Name of the secret. Can be templated.
+  existingSecret: ""
+  userKey: admin-user
+  passwordKey: admin-password
+
+## Define command to be executed at startup by grafana container
+## Needed if using `vault-env` to manage secrets (ref: https://banzaicloud.com/blog/inject-secrets-into-pods-vault/)
+## Default is "run.sh" as defined in grafana's Dockerfile
+# command:
+# - "sh"
+# - "/run.sh"
+
+## Optionally define args if command is used
+## Needed if using `hashicorp/envconsul` to manage secrets
+## By default no arguments are set
+# args:
+# - "-secret"
+# - "secret/grafana"
+# - "./grafana"
+
+## Extra environment variables that will be pass onto deployment pods
+##
+## to provide grafana with access to CloudWatch on AWS EKS:
+## 1. create an iam role of type "Web identity" with provider oidc.eks.* (note the provider for later)
+## 2. edit the "Trust relationships" of the role, add a line inside the StringEquals clause using the
+## same oidc eks provider as noted before (same as the existing line)
+## also, replace NAMESPACE and prometheus-operator-grafana with the service account namespace and name
+##
+##  "oidc.eks.us-east-1.amazonaws.com/id/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:sub": "system:serviceaccount:NAMESPACE:prometheus-operator-grafana",
+##
+## 3. attach a policy to the role, you can use a built in policy called CloudWatchReadOnlyAccess
+## 4. use the following env: (replace 123456789000 and iam-role-name-here with your aws account number and role name)
+##
+## env:
+##   AWS_ROLE_ARN: arn:aws:iam::123456789000:role/iam-role-name-here
+##   AWS_WEB_IDENTITY_TOKEN_FILE: /var/run/secrets/eks.amazonaws.com/serviceaccount/token
+##   AWS_REGION: us-east-1
+##
+## 5. uncomment the EKS section in extraSecretMounts: below
+## 6. uncomment the annotation section in the serviceAccount: above
+## make sure to replace arn:aws:iam::123456789000:role/iam-role-name-here with your role arn
+
+env: {}
+
+## "valueFrom" environment variable references that will be added to deployment pods. Name is templated.
+## ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#envvarsource-v1-core
+## Renders in container spec as:
+##   env:
+##     ...
+##     - name: <key>
+##       valueFrom:
+##         <value rendered as YAML>
+envValueFrom: {}
+  #  ENV_NAME:
+  #    configMapKeyRef:
+  #      name: configmap-name
+  #      key: value_key
+
+## The name of a secret in the same kubernetes namespace which contain values to be added to the environment
+## This can be useful for auth tokens, etc. Value is templated.
+envFromSecret: ""
+
+## Sensible environment variables that will be rendered as new secret object
+## This can be useful for auth tokens, etc.
+## If the secret values contains "{{", they'll need to be properly escaped so that they are not interpreted by Helm
+## ref: https://helm.sh/docs/howto/charts_tips_and_tricks/#using-the-tpl-function
+envRenderSecret: {}
+
+## The names of secrets in the same kubernetes namespace which contain values to be added to the environment
+## Each entry should contain a name key, and can optionally specify whether the secret must be defined with an optional key.
+## Name is templated.
+envFromSecrets: []
+## - name: secret-name
+##   prefix: prefix
+##   optional: true
+
+## The names of conifgmaps in the same kubernetes namespace which contain values to be added to the environment
+## Each entry should contain a name key, and can optionally specify whether the configmap must be defined with an optional key.
+## Name is templated.
+## ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#configmapenvsource-v1-core
+envFromConfigMaps: []
+## - name: configmap-name
+##   prefix: prefix
+##   optional: true
+
+# Inject Kubernetes services as environment variables.
+# See https://kubernetes.io/docs/concepts/services-networking/connect-applications-service/#environment-variables
+enableServiceLinks: true
+
+## Additional grafana server secret mounts
+# Defines additional mounts with secrets. Secrets must be manually created in the namespace.
+extraSecretMounts: []
+  # - name: secret-files
+  #   mountPath: /etc/secrets
+  #   secretName: grafana-secret-files
+  #   readOnly: true
+  #   subPath: ""
+  #
+  # for AWS EKS (cloudwatch) use the following (see also instruction in env: above)
+  # - name: aws-iam-token
+  #   mountPath: /var/run/secrets/eks.amazonaws.com/serviceaccount
+  #   readOnly: true
+  #   projected:
+  #     defaultMode: 420
+  #     sources:
+  #       - serviceAccountToken:
+  #           audience: sts.amazonaws.com
+  #           expirationSeconds: 86400
+  #           path: token
+  #
+  # for CSI e.g. Azure Key Vault use the following
+  # - name: secrets-store-inline
+  #  mountPath: /run/secrets
+  #  readOnly: true
+  #  csi:
+  #    driver: secrets-store.csi.k8s.io
+  #    readOnly: true
+  #    volumeAttributes:
+  #      secretProviderClass: "akv-grafana-spc"
+  #    nodePublishSecretRef:                       # Only required when using service principal mode
+  #       name: grafana-akv-creds                  # Only required when using service principal mode
+
+## Additional grafana server volume mounts
+# Defines additional volume mounts.
+extraVolumeMounts: []
+  # - name: extra-volume-0
+  #   mountPath: /mnt/volume0
+  #   readOnly: true
+  # - name: extra-volume-1
+  #   mountPath: /mnt/volume1
+  #   readOnly: true
+  # - name: grafana-secrets
+  #   mountPath: /mnt/volume2
+
+## Additional Grafana server volumes
+extraVolumes: []
+  # - name: extra-volume-0
+  #   existingClaim: volume-claim
+  # - name: extra-volume-1
+  #   hostPath:
+  #     path: /usr/shared/
+  #     type: ""
+  # - name: grafana-secrets
+  #   csi:
+  #     driver: secrets-store.csi.k8s.io
+  #     readOnly: true
+  #     volumeAttributes:
+  #       secretProviderClass: "grafana-env-spc"
+
+## Container Lifecycle Hooks. Execute a specific bash command or make an HTTP request
+lifecycleHooks: {}
+  # postStart:
+  #   exec:
+  #     command: []
+
+## Pass the plugins you want installed as a list.
+##
+plugins: []
+  # - digrich-bubblechart-panel
+  # - grafana-clock-panel
+  ## You can also use other plugin download URL, as long as they are valid zip files,
+  ## and specify the name of the plugin after the semicolon. Like this:
+  # - https://grafana.com/api/plugins/marcusolsson-json-datasource/versions/1.3.2/download;marcusolsson-json-datasource
+
+## Configure grafana datasources
+## ref: http://docs.grafana.org/administration/provisioning/#datasources
+##
+datasources:
+  datasources.yaml:
+    apiVersion: 1
+    datasources:
+    - name: Loki
+      type: loki
+      url: http://loki-loki-distributed-gateway.monitoring.svc
+      access: proxy
+#      isDefault: true
+#    - name: CloudWatch
+#      type: cloudwatch
+#      access: proxy
+#      uid: cloudwatch
+#      editable: false
+      jsonData:
+        timeout: 60
+        maxLines: 1000
+#        authType: default
+#        defaultRegion: us-east-1
+#    deleteDatasources: []
+#    - name: Prometheus
+
+## Configure grafana alerting (can be templated)
+## ref: http://docs.grafana.org/administration/provisioning/#alerting
+##
+alerting: {}
+  # rules.yaml:
+  #   apiVersion: 1
+  #   groups:
+  #     - orgId: 1
+  #       name: '{{ .Chart.Name }}_my_rule_group'
+  #       folder: my_first_folder
+  #       interval: 60s
+  #       rules:
+  #         - uid: my_id_1
+  #           title: my_first_rule
+  #           condition: A
+  #           data:
+  #             - refId: A
+  #               datasourceUid: '-100'
+  #               model:
+  #                 conditions:
+  #                   - evaluator:
+  #                       params:
+  #                         - 3
+  #                       type: gt
+  #                     operator:
+  #                       type: and
+  #                     query:
+  #                       params:
+  #                         - A
+  #                     reducer:
+  #                       type: last
+  #                     type: query
+  #                 datasource:
+  #                   type: __expr__
+  #                   uid: '-100'
+  #                 expression: 1==0
+  #                 intervalMs: 1000
+  #                 maxDataPoints: 43200
+  #                 refId: A
+  #                 type: math
+  #           dashboardUid: my_dashboard
+  #           panelId: 123
+  #           noDataState: Alerting
+  #           for: 60s
+  #           annotations:
+  #             some_key: some_value
+  #           labels:
+  #             team: sre_team_1
+  # contactpoints.yaml:
+  #   secret:
+  #     apiVersion: 1
+  #     contactPoints:
+  #       - orgId: 1
+  #         name: cp_1
+  #         receivers:
+  #           - uid: first_uid
+  #             type: pagerduty
+  #             settings:
+  #               integrationKey: XXX
+  #               severity: critical
+  #               class: ping failure
+  #               component: Grafana
+  #               group: app-stack
+  #               summary: |
+  #                 {{ `{{ include "default.message" . }}` }}
+
+## Configure notifiers
+## ref: http://docs.grafana.org/administration/provisioning/#alert-notification-channels
+##
+notifiers: {}
+#  notifiers.yaml:
+#    notifiers:
+#    - name: email-notifier
+#      type: email
+#      uid: email1
+#      # either:
+#      org_id: 1
+#      # or
+#      org_name: Main Org.
+#      is_default: true
+#      settings:
+#        addresses: an_email_address@example.com
+#    delete_notifiers:
+
+## Configure grafana dashboard providers
+## ref: http://docs.grafana.org/administration/provisioning/#dashboards
+##
+## `path` must be /var/lib/grafana/dashboards/<provider_name>
+##
+dashboardProviders: {}
+#  dashboardproviders.yaml:
+#    apiVersion: 1
+#    providers:
+#    - name: 'default'
+#      orgId: 1
+#      folder: ''
+#      type: file
+#      disableDeletion: false
+#      editable: true
+#      options:
+#        path: /var/lib/grafana/dashboards/default
+
+## Configure grafana dashboard to import
+## NOTE: To use dashboards you must also enable/configure dashboardProviders
+## ref: https://grafana.com/dashboards
+##
+## dashboards per provider, use provider name as key.
+##
+dashboards: {}
+  # default:
+  #   some-dashboard:
+  #     json: |
+  #       $RAW_JSON
+  #   custom-dashboard:
+  #     file: dashboards/custom-dashboard.json
+  #   prometheus-stats:
+  #     gnetId: 2
+  #     revision: 2
+  #     datasource: Prometheus
+  #   local-dashboard:
+  #     url: https://example.com/repository/test.json
+  #     token: ''
+  #   local-dashboard-base64:
+  #     url: https://example.com/repository/test-b64.json
+  #     token: ''
+  #     b64content: true
+  #   local-dashboard-gitlab:
+  #     url: https://example.com/repository/test-gitlab.json
+  #     gitlabToken: ''
+  #   local-dashboard-bitbucket:
+  #     url: https://example.com/repository/test-bitbucket.json
+  #     bearerToken: ''
+  #   local-dashboard-azure:
+  #     url: https://example.com/repository/test-azure.json
+  #     basic: ''
+  #     acceptHeader: '*/*'
+
+## Reference to external ConfigMap per provider. Use provider name as key and ConfigMap name as value.
+## A provider dashboards must be defined either by external ConfigMaps or in values.yaml, not in both.
+## ConfigMap data example:
+##
+## data:
+##   example-dashboard.json: |
+##     RAW_JSON
+##
+dashboardsConfigMaps: {}
+#  default: ""
+
+## Grafana's primary configuration
+## NOTE: values in map will be converted to ini format
+## ref: http://docs.grafana.org/installation/configuration/
+##
+grafana.ini:
+  paths:
+    data: /var/lib/grafana/
+    logs: /var/log/grafana
+    plugins: /var/lib/grafana/plugins
+    provisioning: /etc/grafana/provisioning
+  analytics:
+    check_for_updates: true
+  log:
+    mode: console
+  grafana_net:
+    url: https://grafana.net
+  server:
+    domain: "{{ if (and .Values.ingress.enabled .Values.ingress.hosts) }}{{ .Values.ingress.hosts | first }}{{ else }}''{{ end }}"
+## grafana Authentication can be enabled with the following values on grafana.ini
+ # server:
+      # The full public facing url you use in browser, used for redirects and emails
+ #    root_url:
+ # https://grafana.com/docs/grafana/latest/auth/github/#enable-github-in-grafana
+ # auth.github:
+ #    enabled: false
+ #    allow_sign_up: false
+ #    scopes: user:email,read:org
+ #    auth_url: https://github.com/login/oauth/authorize
+ #    token_url: https://github.com/login/oauth/access_token
+ #    api_url: https://api.github.com/user
+ #    team_ids:
+ #    allowed_organizations:
+ #    client_id:
+ #    client_secret:
+## LDAP Authentication can be enabled with the following values on grafana.ini
+## NOTE: Grafana will fail to start if the value for ldap.toml is invalid
+  # auth.ldap:
+  #   enabled: true
+  #   allow_sign_up: true
+  #   config_file: /etc/grafana/ldap.toml
+
+## Grafana's LDAP configuration
+## Templated by the template in _helpers.tpl
+## NOTE: To enable the grafana.ini must be configured with auth.ldap.enabled
+## ref: http://docs.grafana.org/installation/configuration/#auth-ldap
+## ref: http://docs.grafana.org/installation/ldap/#configuration
+ldap:
+  enabled: false
+  # `existingSecret` is a reference to an existing secret containing the ldap configuration
+  # for Grafana in a key `ldap-toml`.
+  existingSecret: ""
+  # `config` is the content of `ldap.toml` that will be stored in the created secret
+  config: ""
+  # config: |-
+  #   verbose_logging = true
+
+  #   [[servers]]
+  #   host = "my-ldap-server"
+  #   port = 636
+  #   use_ssl = true
+  #   start_tls = false
+  #   ssl_skip_verify = false
+  #   bind_dn = "uid=%s,ou=users,dc=myorg,dc=com"
+
+## Grafana's SMTP configuration
+## NOTE: To enable, grafana.ini must be configured with smtp.enabled
+## ref: http://docs.grafana.org/installation/configuration/#smtp
+smtp:
+  # `existingSecret` is a reference to an existing secret containing the smtp configuration
+  # for Grafana.
+  existingSecret: ""
+  userKey: "user"
+  passwordKey: "password"
+
+## Sidecars that collect the configmaps with specified label and stores the included files them into the respective folders
+## Requires at least Grafana 5 to work and can't be used together with parameters dashboardProviders, datasources and dashboards
+sidecar:
+  image:
+    # -- The Docker registry
+    registry: quay.io
+    repository: kiwigrid/k8s-sidecar
+    tag: 1.26.1
+    sha: ""
+  imagePullPolicy: IfNotPresent
+  resources: {}
+#   limits:
+#     cpu: 100m
+#     memory: 100Mi
+#   requests:
+#     cpu: 50m
+#     memory: 50Mi
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
+    seccompProfile:
+      type: RuntimeDefault
+  # skipTlsVerify Set to true to skip tls verification for kube api calls
+  # skipTlsVerify: true
+  enableUniqueFilenames: false
+  readinessProbe: {}
+  livenessProbe: {}
+  # Log level default for all sidecars. Can be one of: DEBUG, INFO, WARN, ERROR, CRITICAL. Defaults to INFO
+  # logLevel: INFO
+  alerts:
+    enabled: false
+    # Additional environment variables for the alerts sidecar
+    env: {}
+    # Do not reprocess already processed unchanged resources on k8s API reconnect.
+    # ignoreAlreadyProcessed: true
+    # label that the configmaps with alert are marked with
+    label: grafana_alert
+    # value of label that the configmaps with alert are set to
+    labelValue: ""
+    # Log level. Can be one of: DEBUG, INFO, WARN, ERROR, CRITICAL.
+    # logLevel: INFO
+    # If specified, the sidecar will search for alert config-maps inside this namespace.
+    # Otherwise the namespace in which the sidecar is running will be used.
+    # It's also possible to specify ALL to search in all namespaces
+    searchNamespace: null
+    # Method to use to detect ConfigMap changes. With WATCH the sidecar will do a WATCH requests, with SLEEP it will list all ConfigMaps, then sleep for 60 seconds.
+    watchMethod: WATCH
+    # search in configmap, secret or both
+    resource: both
+    # watchServerTimeout: request to the server, asking it to cleanly close the connection after that.
+    # defaults to 60sec; much higher values like 3600 seconds (1h) are feasible for non-Azure K8S
+    # watchServerTimeout: 3600
+    #
+    # watchClientTimeout: is a client-side timeout, configuring your local socket.
+    # If you have a network outage dropping all packets with no RST/FIN,
+    # this is how long your client waits before realizing & dropping the connection.
+    # defaults to 66sec (sic!)
+    # watchClientTimeout: 60
+    #
+    # Endpoint to send request to reload alerts
+    reloadURL: "http://localhost:3000/api/admin/provisioning/alerting/reload"
+    # Absolute path to shell script to execute after a alert got reloaded
+    script: null
+    skipReload: false
+    # This is needed if skipReload is true, to load any alerts defined at startup time.
+    # Deploy the alert sidecar as an initContainer.
+    initAlerts: false
+    # Additional alert sidecar volume mounts
+    extraMounts: []
+    # Sets the size limit of the alert sidecar emptyDir volume
+    sizeLimit: {}
+  dashboards:
+    enabled: false
+    # Additional environment variables for the dashboards sidecar
+    env: {}
+    # Do not reprocess already processed unchanged resources on k8s API reconnect.
+    # ignoreAlreadyProcessed: true
+    SCProvider: true
+    # label that the configmaps with dashboards are marked with
+    label: grafana_dashboard
+    # value of label that the configmaps with dashboards are set to
+    labelValue: ""
+    # Log level. Can be one of: DEBUG, INFO, WARN, ERROR, CRITICAL.
+    # logLevel: INFO
+    # folder in the pod that should hold the collected dashboards (unless `defaultFolderName` is set)
+    folder: /tmp/dashboards
+    # The default folder name, it will create a subfolder under the `folder` and put dashboards in there instead
+    defaultFolderName: null
+    # Namespaces list. If specified, the sidecar will search for config-maps/secrets inside these namespaces.
+    # Otherwise the namespace in which the sidecar is running will be used.
+    # It's also possible to specify ALL to search in all namespaces.
+    searchNamespace: null
+    # Method to use to detect ConfigMap changes. With WATCH the sidecar will do a WATCH requests, with SLEEP it will list all ConfigMaps, then sleep for 60 seconds.
+    watchMethod: WATCH
+    # search in configmap, secret or both
+    resource: both
+    # If specified, the sidecar will look for annotation with this name to create folder and put graph here.
+    # You can use this parameter together with `provider.foldersFromFilesStructure`to annotate configmaps and create folder structure.
+    folderAnnotation: null
+    # Endpoint to send request to reload alerts
+    reloadURL: "http://localhost:3000/api/admin/provisioning/dashboards/reload"
+    # Absolute path to shell script to execute after a configmap got reloaded
+    script: null
+    skipReload: false
+    # watchServerTimeout: request to the server, asking it to cleanly close the connection after that.
+    # defaults to 60sec; much higher values like 3600 seconds (1h) are feasible for non-Azure K8S
+    # watchServerTimeout: 3600
+    #
+    # watchClientTimeout: is a client-side timeout, configuring your local socket.
+    # If you have a network outage dropping all packets with no RST/FIN,
+    # this is how long your client waits before realizing & dropping the connection.
+    # defaults to 66sec (sic!)
+    # watchClientTimeout: 60
+    #
+    # provider configuration that lets grafana manage the dashboards
+    provider:
+      # name of the provider, should be unique
+      name: sidecarProvider
+      # orgid as configured in grafana
+      orgid: 1
+      # folder in which the dashboards should be imported in grafana
+      folder: ''
+      # type of the provider
+      type: file
+      # disableDelete to activate a import-only behaviour
+      disableDelete: false
+      # allow updating provisioned dashboards from the UI
+      allowUiUpdates: false
+      # allow Grafana to replicate dashboard structure from filesystem
+      foldersFromFilesStructure: false
+    # Additional dashboard sidecar volume mounts
+    extraMounts: []
+    # Sets the size limit of the dashboard sidecar emptyDir volume
+    sizeLimit: {}
+  datasources:
+    enabled: false
+    # Additional environment variables for the datasourcessidecar
+    env: {}
+    envValueFrom: {}
+    # Do not reprocess already processed unchanged resources on k8s API reconnect.
+    # ignoreAlreadyProcessed: true
+    # label that the configmaps with datasources are marked with
+    label: grafana_datasource
+    # value of label that the configmaps with datasources are set to
+    labelValue: ""
+    # Log level. Can be one of: DEBUG, INFO, WARN, ERROR, CRITICAL.
+    # logLevel: INFO
+    # If specified, the sidecar will search for datasource config-maps inside this namespace.
+    # Otherwise the namespace in which the sidecar is running will be used.
+    # It's also possible to specify ALL to search in all namespaces
+    searchNamespace: null
+    # Method to use to detect ConfigMap changes. With WATCH the sidecar will do a WATCH requests, with SLEEP it will list all ConfigMaps, then sleep for 60 seconds.
+    watchMethod: WATCH
+    # search in configmap, secret or both
+    resource: both
+    # watchServerTimeout: request to the server, asking it to cleanly close the connection after that.
+    # defaults to 60sec; much higher values like 3600 seconds (1h) are feasible for non-Azure K8S
+    # watchServerTimeout: 3600
+    #
+    # watchClientTimeout: is a client-side timeout, configuring your local socket.
+    # If you have a network outage dropping all packets with no RST/FIN,
+    # this is how long your client waits before realizing & dropping the connection.
+    # defaults to 66sec (sic!)
+    # watchClientTimeout: 60
+    #
+    # Endpoint to send request to reload datasources
+    reloadURL: "http://localhost:3000/api/admin/provisioning/datasources/reload"
+    # Absolute path to shell script to execute after a datasource got reloaded
+    script: null
+    skipReload: false
+    # This is needed if skipReload is true, to load any datasources defined at startup time.
+    # Deploy the datasources sidecar as an initContainer.
+    initDatasources: false
+    # Sets the size limit of the datasource sidecar emptyDir volume
+    sizeLimit: {}
+  plugins:
+    enabled: false
+    # Additional environment variables for the plugins sidecar
+    env: {}
+    # Do not reprocess already processed unchanged resources on k8s API reconnect.
+    # ignoreAlreadyProcessed: true
+    # label that the configmaps with plugins are marked with
+    label: grafana_plugin
+    # value of label that the configmaps with plugins are set to
+    labelValue: ""
+    # Log level. Can be one of: DEBUG, INFO, WARN, ERROR, CRITICAL.
+    # logLevel: INFO
+    # If specified, the sidecar will search for plugin config-maps inside this namespace.
+    # Otherwise the namespace in which the sidecar is running will be used.
+    # It's also possible to specify ALL to search in all namespaces
+    searchNamespace: null
+    # Method to use to detect ConfigMap changes. With WATCH the sidecar will do a WATCH requests, with SLEEP it will list all ConfigMaps, then sleep for 60 seconds.
+    watchMethod: WATCH
+    # search in configmap, secret or both
+    resource: both
+    # watchServerTimeout: request to the server, asking it to cleanly close the connection after that.
+    # defaults to 60sec; much higher values like 3600 seconds (1h) are feasible for non-Azure K8S
+    # watchServerTimeout: 3600
+    #
+    # watchClientTimeout: is a client-side timeout, configuring your local socket.
+    # If you have a network outage dropping all packets with no RST/FIN,
+    # this is how long your client waits before realizing & dropping the connection.
+    # defaults to 66sec (sic!)
+    # watchClientTimeout: 60
+    #
+    # Endpoint to send request to reload plugins
+    reloadURL: "http://localhost:3000/api/admin/provisioning/plugins/reload"
+    # Absolute path to shell script to execute after a plugin got reloaded
+    script: null
+    skipReload: false
+    # Deploy the datasource sidecar as an initContainer in addition to a container.
+    # This is needed if skipReload is true, to load any plugins defined at startup time.
+    initPlugins: false
+    # Sets the size limit of the plugin sidecar emptyDir volume
+    sizeLimit: {}
+  notifiers:
+    enabled: false
+    # Additional environment variables for the notifierssidecar
+    env: {}
+    # Do not reprocess already processed unchanged resources on k8s API reconnect.
+    # ignoreAlreadyProcessed: true
+    # label that the configmaps with notifiers are marked with
+    label: grafana_notifier
+    # value of label that the configmaps with notifiers are set to
+    labelValue: ""
+    # Log level. Can be one of: DEBUG, INFO, WARN, ERROR, CRITICAL.
+    # logLevel: INFO
+    # If specified, the sidecar will search for notifier config-maps inside this namespace.
+    # Otherwise the namespace in which the sidecar is running will be used.
+    # It's also possible to specify ALL to search in all namespaces
+    searchNamespace: null
+    # Method to use to detect ConfigMap changes. With WATCH the sidecar will do a WATCH requests, with SLEEP it will list all ConfigMaps, then sleep for 60 seconds.
+    watchMethod: WATCH
+    # search in configmap, secret or both
+    resource: both
+    # watchServerTimeout: request to the server, asking it to cleanly close the connection after that.
+    # defaults to 60sec; much higher values like 3600 seconds (1h) are feasible for non-Azure K8S
+    # watchServerTimeout: 3600
+    #
+    # watchClientTimeout: is a client-side timeout, configuring your local socket.
+    # If you have a network outage dropping all packets with no RST/FIN,
+    # this is how long your client waits before realizing & dropping the connection.
+    # defaults to 66sec (sic!)
+    # watchClientTimeout: 60
+    #
+    # Endpoint to send request to reload notifiers
+    reloadURL: "http://localhost:3000/api/admin/provisioning/notifications/reload"
+    # Absolute path to shell script to execute after a notifier got reloaded
+    script: null
+    skipReload: false
+    # Deploy the notifier sidecar as an initContainer in addition to a container.
+    # This is needed if skipReload is true, to load any notifiers defined at startup time.
+    initNotifiers: false
+    # Sets the size limit of the notifier sidecar emptyDir volume
+    sizeLimit: {}
+
+## Override the deployment namespace
+##
+namespaceOverride: ""
+
+## Number of old ReplicaSets to retain
+##
+revisionHistoryLimit: 10
+
+## Add a seperate remote image renderer deployment/service
+imageRenderer:
+  deploymentStrategy: {}
+  # Enable the image-renderer deployment & service
+  enabled: false
+  replicas: 1
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 5
+    targetCPU: "60"
+    targetMemory: ""
+    behavior: {}
+  image:
+    # -- The Docker registry
+    registry: docker.io
+    # image-renderer Image repository
+    repository: grafana/grafana-image-renderer
+    # image-renderer Image tag
+    tag: latest
+    # image-renderer Image sha (optional)
+    sha: ""
+    # image-renderer ImagePullPolicy
+    pullPolicy: Always
+  # extra environment variables
+  env:
+    HTTP_HOST: "0.0.0.0"
+    # RENDERING_ARGS: --no-sandbox,--disable-gpu,--window-size=1280x758
+    # RENDERING_MODE: clustered
+    # IGNORE_HTTPS_ERRORS: true
+
+  ## "valueFrom" environment variable references that will be added to deployment pods. Name is templated.
+  ## ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#envvarsource-v1-core
+  ## Renders in container spec as:
+  ##   env:
+  ##     ...
+  ##     - name: <key>
+  ##       valueFrom:
+  ##         <value rendered as YAML>
+  envValueFrom: {}
+    #  ENV_NAME:
+    #    configMapKeyRef:
+    #      name: configmap-name
+    #      key: value_key
+
+  # image-renderer deployment serviceAccount
+  serviceAccountName: ""
+  # image-renderer deployment securityContext
+  securityContext: {}
+  # image-renderer deployment container securityContext
+  containerSecurityContext:
+    seccompProfile:
+      type: RuntimeDefault
+    capabilities:
+      drop: ['ALL']
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+  ## image-renderer pod annotation
+  podAnnotations: {}
+  # image-renderer deployment Host Aliases
+  hostAliases: []
+  # image-renderer deployment priority class
+  priorityClassName: ''
+  service:
+    # Enable the image-renderer service
+    enabled: true
+    # image-renderer service port name
+    portName: 'http'
+    # image-renderer service port used by both service and deployment
+    port: 8081
+    targetPort: 8081
+    # Adds the appProtocol field to the image-renderer service. This allows to work with istio protocol selection. Ex: "http" or "tcp"
+    appProtocol: ""
+  serviceMonitor:
+    ## If true, a ServiceMonitor CRD is created for a prometheus operator
+    ## https://github.com/coreos/prometheus-operator
+    ##
+    enabled: false
+    path: /metrics
+    #  namespace: monitoring  (defaults to use the namespace this chart is deployed to)
+    labels: {}
+    interval: 1m
+    scheme: http
+    tlsConfig: {}
+    scrapeTimeout: 30s
+    relabelings: []
+    # See: https://doc.crds.dev/github.com/prometheus-operator/kube-prometheus/monitoring.coreos.com/ServiceMonitor/v1@v0.11.0#spec-targetLabels
+    targetLabels: []
+      # - targetLabel1
+      # - targetLabel2
+  # If https is enabled in Grafana, this needs to be set as 'https' to correctly configure the callback used in Grafana
+  grafanaProtocol: http
+  # In case a sub_path is used this needs to be added to the image renderer callback
+  grafanaSubPath: ""
+  # name of the image-renderer port on the pod
+  podPortName: http
+  # number of image-renderer replica sets to keep
+  revisionHistoryLimit: 10
+  networkPolicy:
+    # Enable a NetworkPolicy to limit inbound traffic to only the created grafana pods
+    limitIngress: true
+    # Enable a NetworkPolicy to limit outbound traffic to only the created grafana pods
+    limitEgress: false
+    # Allow additional services to access image-renderer (eg. Prometheus operator when ServiceMonitor is enabled)
+    extraIngressSelectors: []
+  resources: {}
+#   limits:
+#     cpu: 100m
+#     memory: 100Mi
+#   requests:
+#     cpu: 50m
+#     memory: 50Mi
+  ## Node labels for pod assignment
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  #
+  nodeSelector: {}
+
+  ## Tolerations for pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+
+  ## Affinity for pod assignment (evaluated as template)
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ##
+  affinity: {}
+
+  ## Use an alternate scheduler, e.g. "stork".
+  ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+  ##
+  # schedulerName: "default-scheduler"
+
+networkPolicy:
+  ## @param networkPolicy.enabled Enable creation of NetworkPolicy resources. Only Ingress traffic is filtered for now.
+  ##
+  enabled: false
+  ## @param networkPolicy.allowExternal Don't require client label for connections
+  ## The Policy model to apply. When set to false, only pods with the correct
+  ## client label will have network access to  grafana port defined.
+  ## When true, grafana will accept connections from any source
+  ## (with the correct destination port).
+  ##
+  ingress: true
+  ## @param networkPolicy.ingress When true enables the creation
+  ## an ingress network policy
+  ##
+  allowExternal: true
+  ## @param networkPolicy.explicitNamespacesSelector A Kubernetes LabelSelector to explicitly select namespaces from which traffic could be allowed
+  ## If explicitNamespacesSelector is missing or set to {}, only client Pods that are in the networkPolicy's namespace
+  ## and that match other criteria, the ones that have the good label, can reach the grafana.
+  ## But sometimes, we want the grafana to be accessible to clients from other namespaces, in this case, we can use this
+  ## LabelSelector to select these namespaces, note that the networkPolicy's namespace should also be explicitly added.
+  ##
+  ## Example:
+  ## explicitNamespacesSelector:
+  ##   matchLabels:
+  ##     role: frontend
+  ##   matchExpressions:
+  ##    - {key: role, operator: In, values: [frontend]}
+  ##
+  explicitNamespacesSelector: {}
+  ##
+  ##
+  ##
+  ##
+  ##
+  ##
+  egress:
+    ## @param networkPolicy.egress.enabled When enabled, an egress network policy will be
+    ## created allowing grafana to connect to external data sources from kubernetes cluster.
+    enabled: false
+    ##
+    ## @param networkPolicy.egress.blockDNSResolution When enabled, DNS resolution will be blocked
+    ## for all pods in the grafana namespace.
+    blockDNSResolution: false
+    ##
+    ## @param networkPolicy.egress.ports Add individual ports to be allowed by the egress
+    ports: []
+    ## Add ports to the egress by specifying - port: <port number>
+    ## E.X.
+    ## - port: 80
+    ## - port: 443
+    ##
+    ## @param networkPolicy.egress.to Allow egress traffic to specific destinations
+    to: []
+    ## Add destinations to the egress by specifying - ipBlock: <CIDR>
+    ## E.X.
+    ## to:
+    ##  - namespaceSelector:
+    ##    matchExpressions:
+  ##    - {key: role, operator: In, values: [grafana]}
+  ##
+  ##
+  ##
+  ##
+  ##
+
+# Enable backward compatibility of kubernetes where version below 1.13 doesn't have the enableServiceLinks option
+enableKubeBackwardCompatibility: false
+useStatefulSet: false
+# Create a dynamic manifests via values:
+extraObjects: []
+  # - apiVersion: "kubernetes-client.io/v1"
+  #   kind: ExternalSecret
+  #   metadata:
+  #     name: grafana-secrets
+  #   spec:
+  #     backendType: gcpSecretsManager
+  #     data:
+  #       - key: grafana-admin-password
+  #         name: adminPassword
+
+# assertNoLeakedSecrets is a helper function defined in _helpers.tpl that checks if secret
+# values are not exposed in the rendered grafana.ini configmap. It is enabled by default.
+#
+# To pass values into grafana.ini without exposing them in a configmap, use variable expansion:
+# https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#variable-expansion
+#
+# Alternatively, if you wish to allow secret values to be exposed in the rendered grafana.ini configmap,
+# you can disable this check by setting assertNoLeakedSecrets to false.
+assertNoLeakedSecrets: true

--- a/kubernetes-logging/prom_and_loki_values.yaml
+++ b/kubernetes-logging/prom_and_loki_values.yaml
@@ -1,0 +1,1791 @@
+promtail:
+    enabled: true
+    image:
+        # -- The Docker registry
+        registry: cr.yandex/yc-marketplace
+        # -- Docker image repository
+        repository: yandex-cloud/grafana/loki/promtail1711787228740188845175192186348150321748355817562
+        # -- Overrides the image tag whose default is the chart's appVersion
+        tag: "2.7.1"
+        pullPolicy: IfNotPresent
+    affinity: {}
+    annotations: {}
+    config:
+        clients:
+            - url: http://loki-gateway/loki/api/v1/push
+        file: |
+            server:
+              log_level: {{ .Values.config.logLevel }}
+              http_listen_port: {{ .Values.config.serverPort }}
+              {{- with .Values.httpPathPrefix }}
+              http_path_prefix: {{ . }}
+              {{- end }}
+              {{- tpl .Values.config.snippets.extraServerConfigs . | nindent 2 }}
+
+            clients:
+              - url: http://{{ .Release.Name }}-loki-distributed-gateway/loki/api/v1/push
+
+            positions:
+              filename: /run/promtail/positions.yaml
+
+            scrape_configs:
+              {{- tpl .Values.config.snippets.scrapeConfigs . | nindent 2 }}
+              {{- tpl .Values.config.snippets.extraScrapeConfigs . | nindent 2 }}
+
+            limits_config:
+              {{- tpl .Values.config.snippets.extraLimitsConfig . | nindent 2 }}
+        logLevel: info
+        serverPort: !!float 3101
+        snippets:
+            addScrapeJobLabel: false
+            common:
+                - action: replace
+                  source_labels:
+                    - __meta_kubernetes_pod_node_name
+                  target_label: node_name
+                - action: replace
+                  source_labels:
+                    - __meta_kubernetes_namespace
+                  target_label: namespace
+                - action: replace
+                  replacement: $1
+                  separator: /
+                  source_labels:
+                    - namespace
+                    - app
+                  target_label: job
+                - action: replace
+                  source_labels:
+                    - __meta_kubernetes_pod_name
+                  target_label: pod
+                - action: replace
+                  source_labels:
+                    - __meta_kubernetes_pod_container_name
+                  target_label: container
+                - action: replace
+                  replacement: /var/log/pods/*$1/*.log
+                  separator: /
+                  source_labels:
+                    - __meta_kubernetes_pod_uid
+                    - __meta_kubernetes_pod_container_name
+                  target_label: __path__
+                - action: replace
+                  regex: true/(.*)
+                  replacement: /var/log/pods/*$1/*.log
+                  separator: /
+                  source_labels:
+                    - __meta_kubernetes_pod_annotationpresent_kubernetes_io_config_hash
+                    - __meta_kubernetes_pod_annotation_kubernetes_io_config_hash
+                    - __meta_kubernetes_pod_container_name
+                  target_label: __path__
+            extraLimitsConfig: ""
+            extraRelabelConfigs: []
+            extraScrapeConfigs: ""
+            extraServerConfigs: ""
+            pipelineStages:
+                - cri: {}
+            scrapeConfigs: |
+                # See also https://github.com/grafana/loki/blob/master/production/ksonnet/promtail/scrape_config.libsonnet for reference
+                - job_name: kubernetes-pods
+                  pipeline_stages:
+                    {{- toYaml .Values.config.snippets.pipelineStages | nindent 4 }}
+                  kubernetes_sd_configs:
+                    - role: pod
+                  relabel_configs:
+                    - source_labels:
+                        - __meta_kubernetes_pod_controller_name
+                      regex: ([0-9a-z-.]+?)(-[0-9a-f]{8,10})?
+                      action: replace
+                      target_label: __tmp_controller_name
+                    - source_labels:
+                        - __meta_kubernetes_pod_label_app_kubernetes_io_name
+                        - __meta_kubernetes_pod_label_app
+                        - __tmp_controller_name
+                        - __meta_kubernetes_pod_name
+                      regex: ^;*([^;]+)(;.*)?$
+                      action: replace
+                      target_label: app
+                    - source_labels:
+                        - __meta_kubernetes_pod_label_app_kubernetes_io_instance
+                        - __meta_kubernetes_pod_label_release
+                      regex: ^;*([^;]+)(;.*)?$
+                      action: replace
+                      target_label: instance
+                    - source_labels:
+                        - __meta_kubernetes_pod_label_app_kubernetes_io_component
+                        - __meta_kubernetes_pod_label_component
+                      regex: ^;*([^;]+)(;.*)?$
+                      action: replace
+                      target_label: component
+                    {{- if .Values.config.snippets.addScrapeJobLabel }}
+                    - replacement: kubernetes-pods
+                      target_label: scrape_job
+                    {{- end }}
+                    {{- toYaml .Values.config.snippets.common | nindent 4 }}
+                    {{- with .Values.config.snippets.extraRelabelConfigs }}
+                    {{- toYaml . | nindent 4 }}
+                    {{- end }}
+    configmap:
+        enabled: false
+    containerSecurityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+            drop:
+                - ALL
+        readOnlyRootFilesystem: true
+    daemonset:
+        enabled: true
+    defaultVolumeMounts:
+        - mountPath: /run/promtail
+          name: run
+        - mountPath: /var/lib/docker/containers
+          name: containers
+          readOnly: true
+        - mountPath: /var/log/pods
+          name: pods
+          readOnly: true
+    defaultVolumes:
+        - hostPath:
+            path: /run/promtail
+          name: run
+        - hostPath:
+            path: /var/lib/docker/containers
+          name: containers
+        - hostPath:
+            path: /var/log/pods
+          name: pods
+    deployment:
+        autoscaling:
+            enabled: false
+            maxReplicas: !!float 10
+            minReplicas: !!float 1
+            targetCPUUtilizationPercentage: !!float 80
+            targetMemoryUtilizationPercentage: null
+        enabled: false
+        replicaCount: !!float 1
+    enableServiceLinks: true
+    extraArgs: []
+    extraContainers: {}
+    extraEnv: []
+    extraEnvFrom: []
+    extraObjects: []
+    extraPorts: {}
+    extraVolumeMounts: []
+    extraVolumes: []
+    fullnameOverride: null
+    global: {}
+    httpPathPrefix: ""
+    imagePullSecrets: []
+    initContainer: []
+    livenessProbe: {}
+    nameOverride: null
+    namespace: null
+    networkPolicy:
+        enabled: false
+        k8sApi:
+            cidrs: []
+            port: !!float 8443
+        metrics:
+            cidrs: []
+            namespaceSelector: {}
+            podSelector: {}
+    nodeSelector: {}
+    podAnnotations: {}
+    podLabels: {}
+    podSecurityContext:
+        runAsGroup: !!float 0
+        runAsUser: !!float 0
+    podSecurityPolicy:
+        allowPrivilegeEscalation: true
+        fsGroup:
+            rule: RunAsAny
+        hostIPC: false
+        hostNetwork: false
+        hostPID: false
+        privileged: true
+        readOnlyRootFilesystem: true
+        requiredDropCapabilities:
+            - ALL
+        runAsUser:
+            rule: RunAsAny
+        seLinux:
+            rule: RunAsAny
+        supplementalGroups:
+            rule: RunAsAny
+        volumes:
+            - secret
+            - hostPath
+            - downwardAPI
+    priorityClassName: null
+    rbac:
+        create: true
+        pspEnabled: false
+    readinessProbe:
+        failureThreshold: !!float 5
+        httpGet:
+            path: '{{ printf `%s/ready` .Values.httpPathPrefix }}'
+            port: http-metrics
+        initialDelaySeconds: !!float 10
+        periodSeconds: !!float 10
+        successThreshold: !!float 1
+        timeoutSeconds: !!float 1
+    resources: {}
+    secret:
+        annotations: {}
+        labels: {}
+    serviceAccount:
+        annotations: {}
+        create: true
+        imagePullSecrets: []
+        name: null
+    serviceMonitor:
+        annotations: {}
+        enabled: false
+        interval: null
+        labels: {}
+        metricRelabelings: []
+        namespace: null
+        namespaceSelector: {}
+        prometheusRule:
+            additionalLabels: {}
+            enabled: false
+            rules: []
+        relabelings: []
+        scheme: http
+        scrapeTimeout: null
+        targetLabels: []
+        tlsConfig: null
+    tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+          operator: Exists
+        - effect : NoSchedule
+          key: node-role
+          operator: Equal
+          value: infra
+    updateStrategy: {}
+loki-distributed:
+    serviceaccountawskeyvalue: string
+    serviceaccountawskeyvalue_generated:
+        accessKeyID: string
+        secretAccessKey: string
+    global:
+        image: {}
+        # -- configures cluster domain ("cluster.local" by default)
+        clusterDomain: "cluster.local"
+        # -- configures DNS service name
+        dnsService: "kube-dns"
+        # -- configures DNS service namespace
+        dnsNamespace: "kube-system"
+    # -- Image pull secrets for Docker images
+    imagePullSecrets: []
+    loki:
+        # -- If set, these annotations are added to all of the Kubernetes controllers
+        # (Deployments, StatefulSets, etc) that this chart launches. Use this to
+        # implement something like the "Wave" controller or another controller that
+        # is monitoring top level deployment resources.
+        annotations: {}
+        # Configures the readiness probe for all of the Loki pods
+        readinessProbe:
+            httpGet:
+                path: /ready
+                port: http
+            initialDelaySeconds: !!float 30
+            timeoutSeconds: !!float 1
+        livenessProbe:
+            httpGet:
+                path: /ready
+                port: http
+            initialDelaySeconds: !!float 300
+        image:
+            # -- The Docker registry
+            registry: cr.yandex/yc-marketplace
+            # -- Docker image repository
+            repository: yandex-cloud/grafana/loki/loki1711787228740188845175192186348150321748355817562
+            # -- Overrides the image tag whose default is the chart's appVersion
+            tag: "2.6.1"
+            # -- Docker image pull policy
+            pullPolicy: IfNotPresent
+        # -- Common labels for all pods
+        podLabels: {}
+        # -- Common annotations for all pods
+        podAnnotations: {}
+        # -- The number of old ReplicaSets to retain to allow rollback
+        revisionHistoryLimit: !!float 10
+        # -- The SecurityContext for Loki pods
+        podSecurityContext:
+            fsGroup: !!float 10001
+            runAsGroup: !!float 10001
+            runAsNonRoot: true
+            runAsUser: !!float 10001
+        # -- The SecurityContext for Loki containers
+        containerSecurityContext:
+            readOnlyRootFilesystem: true
+            capabilities:
+                drop:
+                    - ALL
+            allowPrivilegeEscalation: false
+        # -- Specify an existing secret containing loki configuration. If non-empty, overrides `loki.config`
+        existingSecretForConfig: ""
+        # -- Adds the appProtocol field to the memberlist service. This allows memberlist to work with istio protocol selection. Ex: "http" or "tcp"
+        appProtocol: ""
+        # -- Common annotations for all loki services
+        serviceAnnotations: {}
+        # -- Config file contents for Loki
+        # @default -- See values.yaml
+        config: |
+            auth_enabled: false
+
+            server:
+              http_listen_port: 3100
+
+            distributor:
+              ring:
+                kvstore:
+                  store: memberlist
+
+            memberlist:
+              join_members:
+                - {{ include "loki.fullname" . }}-memberlist
+
+            ingester:
+              lifecycler:
+                ring:
+                  kvstore:
+                    store: memberlist
+                  replication_factor: 1
+              chunk_idle_period: 30m
+              chunk_block_size: 262144
+              chunk_encoding: snappy
+              chunk_retain_period: 1m
+              max_transfer_retries: 0
+              wal:
+                dir: /var/loki/wal
+
+            limits_config:
+              enforce_metric_name: false
+              reject_old_samples: true
+              reject_old_samples_max_age: 168h
+              max_cache_freshness_per_query: 10m
+              split_queries_by_interval: 15m
+
+            {{- if .Values.loki.schemaConfig}}
+            schema_config:
+            {{- toYaml .Values.loki.schemaConfig | nindent 2}}
+            {{- end}}
+            {{- if .Values.loki.storageConfig}}
+            storage_config:
+            {{- if .Values.indexGateway.enabled}}
+            {{- $indexGatewayClient := dict "server_address" (printf "dns:///%s:9095" (include "loki.indexGatewayFullname" .)) }}
+            {{- $_ := set .Values.loki.storageConfig.boltdb_shipper "index_gateway_client" $indexGatewayClient }}
+            {{- end}}
+            {{- $_ := set .Values.loki.storageConfig.aws "access_key_id" .Values.serviceaccountawskeyvalue_generated.accessKeyID}}
+            {{- $_ := set .Values.loki.storageConfig.aws "secret_access_key" .Values.serviceaccountawskeyvalue_generated.secretAccessKey}}
+            {{- toYaml .Values.loki.storageConfig | nindent 2}}
+            {{- end}}
+
+            runtime_config:
+              file: /var/{{ include "loki.name" . }}-runtime/runtime.yaml
+
+            chunk_store_config:
+              max_look_back_period: 0s
+
+            table_manager:
+              retention_deletes_enabled: false
+              retention_period: 0s
+
+            query_range:
+              align_queries_with_step: true
+              max_retries: 5
+              cache_results: true
+              results_cache:
+                cache:
+                  enable_fifocache: true
+                  fifocache:
+                    max_size_items: 1024
+                    ttl: 24h
+
+            frontend_worker:
+              {{- if .Values.queryScheduler.enabled }}
+              scheduler_address: {{ include "loki.querySchedulerFullname" . }}:9095
+              {{- else }}
+              frontend_address: {{ include "loki.queryFrontendFullname" . }}:9095
+              {{- end }}
+
+            frontend:
+              log_queries_longer_than: 5s
+              compress_responses: true
+              {{- if .Values.queryScheduler.enabled }}
+              scheduler_address: {{ include "loki.querySchedulerFullname" . }}:9095
+              {{- end }}
+              tail_proxy_url: http://{{ include "loki.querierFullname" . }}:3100
+
+            compactor:
+              shared_store: filesystem
+
+            ruler:
+              storage:
+                type: local
+                local:
+                  directory: /etc/loki/rules
+              ring:
+                kvstore:
+                  store: memberlist
+              rule_path: /tmp/loki/scratch
+              alertmanager_url: https://alertmanager.xx
+              external_url: https://alertmanager.xx
+        # -- Check https://grafana.com/docs/loki/latest/configuration/#schema_config for more info on how to configure schemas
+        schemaConfig:
+            configs:
+                - from: "2020-09-07"
+                  store: boltdb-shipper
+                  object_store: s3
+                  schema: v11
+                  index:
+                    prefix: loki_index_
+                    period: 24h
+        # -- Check https://grafana.com/docs/loki/latest/configuration/#storage_config for more info on how to configure storages
+        storageConfig:
+            boltdb_shipper:
+                shared_store: s3
+                active_index_directory: /var/loki/index
+                cache_location: /var/loki/cache
+                cache_ttl: 168h
+            aws:
+                endpoint: storage.yandexcloud.net
+                region: ru-central1
+                access_key_id: string
+                secret_access_key: string
+                insecure: false
+                sse_encryption: false
+                http_config:
+                    idle_conn_timeout: 90s
+                    response_header_timeout: 0s
+                    insecure_skip_verify: false
+                s3forcepathstyle: true
+        # -- Uncomment to configure each storage individually
+        #   azure: {}
+        #   gcs: {}
+        #   s3: {}
+        #   boltdb: {}
+
+        # -- Structured loki configuration, takes precedence over `loki.config`, `loki.schemaConfig`, `loki.storageConfig`
+        structuredConfig: {}
+    # -- Provides a reloadable runtime configuration file for some specific configuration
+    runtimeConfig: {}
+    serviceAccount:
+        # -- Specifies whether a ServiceAccount should be created
+        create: true
+        # -- Image pull secrets for the service account
+        imagePullSecrets: []
+        # -- Annotations for the service account
+        annotations: {}
+        # -- Set this toggle to false to opt out of automounting API credentials for the service account
+        automountServiceAccountToken: true
+    # RBAC configuration
+    rbac:
+        # -- If pspEnabled true, a PodSecurityPolicy is created for K8s that use psp.
+        pspEnabled: false
+        # -- For OpenShift set pspEnabled to 'false' and sccEnabled to 'true' to use the SecurityContextConstraints.
+        sccEnabled: false
+    # ServiceMonitor configuration
+    serviceMonitor:
+        # -- If enabled, ServiceMonitor resources for Prometheus Operator are created
+        enabled: false
+        # -- Namespace selector for ServiceMonitor resources
+        namespaceSelector: {}
+        # -- ServiceMonitor annotations
+        annotations: {}
+        # -- Additional ServiceMonitor labels
+        labels: {}
+        # -- ServiceMonitor relabel configs to apply to samples before scraping
+        # https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
+        relabelings: []
+        # -- ServiceMonitor metric relabel configs to apply to samples before ingestion
+        # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#endpoint
+        metricRelabelings: []
+        # --ServiceMonitor will add labels from the service to the Prometheus metric
+        # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitorspec
+        targetLabels: []
+        # -- ServiceMonitor will use http by default, but you can pick https as well
+        scheme: http
+    # Rules for the Prometheus Operator
+    prometheusRule:
+        # -- If enabled, a PrometheusRule resource for Prometheus Operator is created
+        enabled: false
+        # -- PrometheusRule annotations
+        annotations: {}
+        # -- Additional PrometheusRule labels
+        labels: {}
+        # -- Contents of Prometheus rules file
+        groups: []
+        # - name: loki-rules
+        #   rules:
+        #     - record: job:loki_request_duration_seconds_bucket:sum_rate
+        #       expr: sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, job)
+        #     - record: job_route:loki_request_duration_seconds_bucket:sum_rate
+        #       expr: sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, job, route)
+        #     - record: node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate
+        #       expr: sum(rate(container_cpu_usage_seconds_total[1m])) by (node, namespace, pod, container)
+    # Configuration for the ingester
+    ingester:
+        # -- Kind of deployment [StatefulSet/Deployment]
+        kind: StatefulSet
+        # -- Number of replicas for the ingester
+        replicas: !!float 1
+        autoscaling:
+            # -- Enable autoscaling for the ingester
+            enabled: false
+            # -- Minimum autoscaling replicas for the ingester
+            minReplicas: !!float 1
+            # -- Maximum autoscaling replicas for the ingester
+            maxReplicas: !!float 3
+            # -- Target CPU utilisation percentage for the ingester
+            targetCPUUtilizationPercentage: !!float 60
+        image: {}
+        # -- Labels for ingester pods
+        podLabels: {}
+        # -- Annotations for ingester pods
+        podAnnotations: {}
+        # -- Labels for ingestor service
+        serviceLabels: {}
+        # -- Additional CLI args for the ingester
+        extraArgs: []
+        # -- Environment variables to add to the ingester pods
+        extraEnv: []
+        # -- Environment variables from secrets or configmaps to add to the ingester pods
+        extraEnvFrom: []
+        # -- Volume mounts to add to the ingester pods
+        extraVolumeMounts: []
+        # -- Volumes to add to the ingester pods
+        extraVolumes: []
+        # -- Resource requests and limits for the ingester
+        resources: {}
+        # -- Containers to add to the ingester pods
+        extraContainers: []
+        # -- Init containers to add to the ingester pods
+        initContainers: []
+        # -- Grace period to allow the ingester to shutdown before it is killed. Especially for the ingestor,
+        # this must be increased. It must be long enough so ingesters can be gracefully shutdown flushing/transferring
+        # all data and to successfully leave the member ring on shutdown.
+        terminationGracePeriodSeconds: !!float 300
+        # -- topologySpread for ingester pods. Passed through `tpl` and, thus, to be configured as string
+        # @default -- Defaults to allow skew no more then 1 node per AZ
+        topologySpreadConstraints: |
+            - maxSkew: 1
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+              whenUnsatisfiable: ScheduleAnyway
+              labelSelector:
+                matchLabels:
+                  {{- include "loki.ingesterSelectorLabels" . | nindent 6 }}
+        # -- Affinity for ingester pods. Passed through `tpl` and, thus, to be configured as string
+        # @default -- Hard node and soft zone anti-affinity
+        affinity: |
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchLabels:
+                      {{- include "loki.ingesterSelectorLabels" . | nindent 10 }}
+                  topologyKey: kubernetes.io/hostname
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 100
+                  podAffinityTerm:
+                    labelSelector:
+                      matchLabels:
+                        {{- include "loki.ingesterSelectorLabels" . | nindent 12 }}
+                    topologyKey: failure-domain.beta.kubernetes.io/zone
+        # -- Node selector for ingester pods
+        nodeSelector:
+          node: infra
+        # -- Tolerations for ingester pods
+        tolerations:
+        - effect: NoSchedule
+          key: node-role
+          operator: Equal
+          value: infra
+
+        # -- readiness probe settings for ingester pods. If empty, use `loki.readinessProbe`
+        readinessProbe: {}
+        # -- liveness probe settings for ingester pods. If empty use `loki.livenessProbe`
+        livenessProbe: {}
+        persistence:
+            # -- Enable creating PVCs which is required when using boltdb-shipper
+            enabled: false
+            # -- Use emptyDir with ramdisk for storage. **Please note that all data in ingester will be lost on pod restart**
+            inMemory: false
+            # -- Size of persistent or memory disk
+            size: 10Gi
+        # -- Adds the appProtocol field to the ingester service. This allows ingester to work with istio protocol selection.
+        appProtocol:
+            # -- Set the optional grpc service protocol. Ex: "grpc", "http2" or "https"
+            grpc: ""
+    # Configuration for the distributor
+    distributor:
+        # -- Number of replicas for the distributor
+        replicas: !!float 1
+        autoscaling:
+            # -- Enable autoscaling for the distributor
+            enabled: false
+            # -- Minimum autoscaling replicas for the distributor
+            minReplicas: !!float 1
+            # -- Maximum autoscaling replicas for the distributor
+            maxReplicas: !!float 3
+            # -- Target CPU utilisation percentage for the distributor
+            targetCPUUtilizationPercentage: !!float 60
+        image: {}
+        # -- Labels for distributor pods
+        podLabels: {}
+        # -- Annotations for distributor pods
+        podAnnotations: {}
+        # -- Labels for distributor service
+        serviceLabels: {}
+        # -- Additional CLI args for the distributor
+        extraArgs: []
+        # -- Environment variables to add to the distributor pods
+        extraEnv: []
+        # -- Environment variables from secrets or configmaps to add to the distributor pods
+        extraEnvFrom: []
+        # -- Volume mounts to add to the distributor pods
+        extraVolumeMounts: []
+        # -- Volumes to add to the distributor pods
+        extraVolumes: []
+        # -- Resource requests and limits for the distributor
+        resources: {}
+        # -- Containers to add to the distributor pods
+        extraContainers: []
+        # -- Grace period to allow the distributor to shutdown before it is killed
+        terminationGracePeriodSeconds: !!float 30
+        # -- Affinity for distributor pods. Passed through `tpl` and, thus, to be configured as string
+        # @default -- Hard node and soft zone anti-affinity
+        affinity: |
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchLabels:
+                      {{- include "loki.distributorSelectorLabels" . | nindent 10 }}
+                  topologyKey: kubernetes.io/hostname
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 100
+                  podAffinityTerm:
+                    labelSelector:
+                      matchLabels:
+                        {{- include "loki.distributorSelectorLabels" . | nindent 12 }}
+                    topologyKey: failure-domain.beta.kubernetes.io/zone
+        # -- Node selector for distributor pods
+        nodeSelector:
+          node: infra
+        # -- Tolerations for distributor pods
+        tolerations:
+        - effect: NoSchedule
+          key: node-role
+          operator: Equal
+          value: infra
+
+        # -- Adds the appProtocol field to the distributor service. This allows distributor to work with istio protocol selection.
+        appProtocol:
+            # -- Set the optional grpc service protocol. Ex: "grpc", "http2" or "https"
+            grpc: ""
+    # Configuration for the querier
+    querier:
+        # -- Number of replicas for the querier
+        replicas: !!float 1
+        autoscaling:
+            # -- Enable autoscaling for the querier, this is only used if `queryIndex.enabled: true`
+            enabled: false
+            # -- Minimum autoscaling replicas for the querier
+            minReplicas: !!float 1
+            # -- Maximum autoscaling replicas for the querier
+            maxReplicas: !!float 3
+            # -- Target CPU utilisation percentage for the querier
+            targetCPUUtilizationPercentage: !!float 60
+        image: {}
+        # -- Labels for querier pods
+        podLabels: {}
+        # -- Annotations for querier pods
+        podAnnotations: {}
+        # -- Labels for querier service
+        serviceLabels: {}
+        # -- Additional CLI args for the querier
+        extraArgs: []
+        # -- Environment variables to add to the querier pods
+        extraEnv: []
+        # -- Environment variables from secrets or configmaps to add to the querier pods
+        extraEnvFrom: []
+        # -- Volume mounts to add to the querier pods
+        extraVolumeMounts: []
+        # -- Volumes to add to the querier pods
+        extraVolumes: []
+        # -- Resource requests and limits for the querier
+        resources: {}
+        # -- Containers to add to the querier pods
+        extraContainers: []
+        # -- Init containers to add to the querier pods
+        initContainers: []
+        # -- Grace period to allow the querier to shutdown before it is killed
+        terminationGracePeriodSeconds: !!float 30
+        # -- topologySpread for querier pods. Passed through `tpl` and, thus, to be configured as string
+        # @default -- Defaults to allow skew no more then 1 node per AZ
+        topologySpreadConstraints: |
+            - maxSkew: 1
+              topologyKey: kubernetes.io/hostname
+              whenUnsatisfiable: ScheduleAnyway
+              labelSelector:
+                matchLabels:
+                  {{- include "loki.querierSelectorLabels" . | nindent 6 }}
+        # -- Affinity for querier pods. Passed through `tpl` and, thus, to be configured as string
+        # @default -- Hard node and soft zone anti-affinity
+        affinity: {}
+        # -- Node selector for querier pods
+        nodeSelector:
+          node: infra
+        # -- Tolerations for querier pods
+        tolerations:
+        - effect: NoSchedule
+          key: node-role
+          operator: Equal
+          value: infra
+
+        # -- DNSConfig for querier pods
+        dnsConfig: {}
+        persistence:
+            # -- Enable creating PVCs for the querier cache
+            enabled: false
+            # -- Size of persistent disk
+            size: 10Gi
+        # -- Adds the appProtocol field to the querier service. This allows querier to work with istio protocol selection.
+        appProtocol:
+            # -- Set the optional grpc service protocol. Ex: "grpc", "http2" or "https"
+            grpc: ""
+    # Configuration for the query-frontend
+    queryFrontend:
+        # -- Number of replicas for the query-frontend
+        replicas: !!float 1
+        autoscaling:
+            # -- Enable autoscaling for the query-frontend
+            enabled: false
+            # -- Minimum autoscaling replicas for the query-frontend
+            minReplicas: !!float 1
+            # -- Maximum autoscaling replicas for the query-frontend
+            maxReplicas: !!float 3
+            # -- Target CPU utilisation percentage for the query-frontend
+            targetCPUUtilizationPercentage: !!float 60
+        image: {}
+        # -- Labels for query-frontend pods
+        podLabels: {}
+        # -- Annotations for query-frontend pods
+        podAnnotations: {}
+        # -- Labels for query-frontend service
+        serviceLabels: {}
+        # -- Additional CLI args for the query-frontend
+        extraArgs: []
+        # -- Environment variables to add to the query-frontend pods
+        extraEnv: []
+        # -- Environment variables from secrets or configmaps to add to the query-frontend pods
+        extraEnvFrom: []
+        # -- Volume mounts to add to the query-frontend pods
+        extraVolumeMounts: []
+        # -- Volumes to add to the query-frontend pods
+        extraVolumes: []
+        # -- Resource requests and limits for the query-frontend
+        resources: {}
+        # -- Containers to add to the query-frontend pods
+        extraContainers: []
+        # -- Grace period to allow the query-frontend to shutdown before it is killed
+        terminationGracePeriodSeconds: !!float 30
+        # -- Affinity for query-frontend pods. Passed through `tpl` and, thus, to be configured as string
+        # @default -- Hard node and soft zone anti-affinity
+        affinity: |
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchLabels:
+                      {{- include "loki.queryFrontendSelectorLabels" . | nindent 10 }}
+                  topologyKey: kubernetes.io/hostname
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 100
+                  podAffinityTerm:
+                    labelSelector:
+                      matchLabels:
+                        {{- include "loki.queryFrontendSelectorLabels" . | nindent 12 }}
+                    topologyKey: failure-domain.beta.kubernetes.io/zone
+        # -- Node selector for query-frontend pods
+        nodeSelector:
+          node: infra
+        # -- Tolerations for query-frontend pods
+        tolerations:
+        - effect: NoSchedule
+          key: node-role
+          operator: Equal
+          value: infra
+
+        # -- Adds the appProtocol field to the queryFrontend service. This allows queryFrontend to work with istio protocol selection.
+        appProtocol:
+            # -- Set the optional grpc service protocol. Ex: "grpc", "http2" or "https"
+            grpc: ""
+    # Configuration for the query-scheduler
+    queryScheduler:
+        # -- Specifies whether the query-scheduler should be decoupled from the query-frontend
+        enabled: false
+        # -- Number of replicas for the query-scheduler.
+        # It should be lower than `-querier.max-concurrent` to avoid generating back-pressure in queriers;
+        # it's also recommended that this value evenly divides the latter
+        replicas: !!float 2
+        image: {}
+        # -- Labels for query-scheduler pods
+        podLabels: {}
+        # -- Annotations for query-scheduler pods
+        podAnnotations: {}
+        # -- Labels for query-scheduler service
+        serviceLabels: {}
+        # -- Additional CLI args for the query-scheduler
+        extraArgs: []
+        # -- Environment variables to add to the query-scheduler pods
+        extraEnv: []
+        # -- Environment variables from secrets or configmaps to add to the query-scheduler pods
+        extraEnvFrom: []
+        # -- Volume mounts to add to the query-scheduler pods
+        extraVolumeMounts: []
+        # -- Volumes to add to the query-scheduler pods
+        extraVolumes: []
+        # -- Resource requests and limits for the query-scheduler
+        resources: {}
+        # -- Containers to add to the query-scheduler pods
+        extraContainers: []
+        # -- Grace period to allow the query-scheduler to shutdown before it is killed
+        terminationGracePeriodSeconds: !!float 30
+        # -- Affinity for query-scheduler pods. Passed through `tpl` and, thus, to be configured as string
+        # @default -- Hard node and soft zone anti-affinity
+        affinity: |
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchLabels:
+                      {{- include "loki.querySchedulerSelectorLabels" . | nindent 10 }}
+                  topologyKey: kubernetes.io/hostname
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 100
+                  podAffinityTerm:
+                    labelSelector:
+                      matchLabels:
+                        {{- include "loki.querySchedulerSelectorLabels" . | nindent 12 }}
+                    topologyKey: failure-domain.beta.kubernetes.io/zone
+        # -- Pod Disruption Budget maxUnavailable
+        maxUnavailable: !!float 1
+        # -- Node selector for query-scheduler pods
+        nodeSelector: {}
+        # -- Tolerations for query-scheduler pods
+        tolerations: []
+    # Configuration for the table-manager
+    tableManager:
+        # -- Specifies whether the table-manager should be enabled
+        enabled: false
+        image: {}
+        # -- Labels for table-manager pods
+        podLabels: {}
+        # -- Annotations for table-manager pods
+        podAnnotations: {}
+        # -- Labels for table-manager service
+        serviceLabels: {}
+        # -- Additional CLI args for the table-manager
+        extraArgs: []
+        # -- Environment variables to add to the table-manager pods
+        extraEnv: []
+        # -- Environment variables from secrets or configmaps to add to the table-manager pods
+        extraEnvFrom: []
+        # -- Volume mounts to add to the table-manager pods
+        extraVolumeMounts: []
+        # -- Volumes to add to the table-manager pods
+        extraVolumes: []
+        # -- Resource requests and limits for the table-manager
+        resources: {}
+        # -- Containers to add to the table-manager pods
+        extraContainers: []
+        # -- Grace period to allow the table-manager to shutdown before it is killed
+        terminationGracePeriodSeconds: !!float 30
+        # -- Affinity for table-manager pods. Passed through `tpl` and, thus, to be configured as string
+        # @default -- Hard node and soft zone anti-affinity
+        affinity: |
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchLabels:
+                      {{- include "loki.tableManagerSelectorLabels" . | nindent 10 }}
+                  topologyKey: kubernetes.io/hostname
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 100
+                  podAffinityTerm:
+                    labelSelector:
+                      matchLabels:
+                        {{- include "loki.tableManagerSelectorLabels" . | nindent 12 }}
+                    topologyKey: failure-domain.beta.kubernetes.io/zone
+        # -- Node selector for table-manager pods
+        nodeSelector:
+          node: infra
+        # -- Tolerations for table-manager pods
+        tolerations:
+        - effect: NoSchedule
+          key: node-role
+          operator: Equal
+          value: infra
+
+    # Use either this ingress or the gateway, but not both at once.
+    # If you enable this, make sure to disable the gateway.
+    # You'll need to supply authn configuration for your ingress controller.
+    ingress:
+        enabled: false
+        #  ingressClassName: nginx
+        annotations: {}
+        #    nginx.ingress.kubernetes.io/auth-type: basic
+        #    nginx.ingress.kubernetes.io/auth-secret: loki-distributed-basic-auth
+        #    nginx.ingress.kubernetes.io/auth-secret-type: auth-map
+        #    nginx.ingress.kubernetes.io/configuration-snippet: |
+        #      proxy_set_header X-Scope-OrgID $remote_user;
+        paths:
+            distributor:
+                - /api/prom/push
+                - /loki/api/v1/push
+            querier:
+                - /api/prom/tail
+                - /loki/api/v1/tail
+            query-frontend:
+                - /loki/api
+            ruler:
+                - /api/prom/rules
+                - /loki/api/v1/rules
+                - /prometheus/api/v1/rules
+                - /prometheus/api/v1/alerts
+        hosts:
+            - loki.example.com
+    #  tls:
+    #    - hosts:
+    #       - loki.example.com
+    #      secretName: loki-distributed-tls
+
+    # Configuration for the gateway
+    gateway:
+        # -- Specifies whether the gateway should be enabled
+        enabled: true
+        # -- Number of replicas for the gateway
+        replicas: !!float 1
+        # -- Enable logging of 2xx and 3xx HTTP requests
+        verboseLogging: true
+        autoscaling:
+            # -- Enable autoscaling for the gateway
+            enabled: false
+            # -- Minimum autoscaling replicas for the gateway
+            minReplicas: !!float 1
+            # -- Maximum autoscaling replicas for the gateway
+            maxReplicas: !!float 3
+            # -- Target CPU utilisation percentage for the gateway
+            targetCPUUtilizationPercentage: !!float 60
+        # -- See `kubectl explain deployment.spec.strategy` for more,
+        # ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+        deploymentStrategy:
+            type: RollingUpdate
+        image:
+            # -- The Docker registry for the gateway image
+            registry: cr.yandex/yc-marketplace
+            # -- The gateway image repository
+            repository: yandex-cloud/grafana/loki/nginx-unprivileged1711787228740188845175192186348150321748355817562
+            # -- The gateway image tag
+            tag: 1.19-alpine
+            # -- The gateway image pull policy
+            pullPolicy: IfNotPresent
+        # -- Labels for gateway pods
+        podLabels: {}
+        # -- Annotations for gateway pods
+        podAnnotations: {}
+        # -- Additional CLI args for the gateway
+        extraArgs: []
+        # -- Environment variables to add to the gateway pods
+        extraEnv: []
+        # -- Environment variables from secrets or configmaps to add to the gateway pods
+        extraEnvFrom: []
+        # -- Volumes to add to the gateway pods
+        extraVolumes: []
+        # -- Volume mounts to add to the gateway pods
+        extraVolumeMounts: []
+        # -- The SecurityContext for gateway containers
+        podSecurityContext:
+            fsGroup: !!float 101
+            runAsGroup: !!float 101
+            runAsNonRoot: true
+            runAsUser: !!float 101
+        # -- The SecurityContext for gateway containers
+        containerSecurityContext:
+            readOnlyRootFilesystem: true
+            capabilities:
+                drop:
+                    - ALL
+            allowPrivilegeEscalation: false
+        # -- Resource requests and limits for the gateway
+        resources: {}
+        # -- Containers to add to the gateway pods
+        extraContainers: []
+        # -- Grace period to allow the gateway to shutdown before it is killed
+        terminationGracePeriodSeconds: !!float 30
+        # -- Affinity for gateway pods. Passed through `tpl` and, thus, to be configured as string
+        # @default -- Hard node and soft zone anti-affinity
+        affinity: |
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchLabels:
+                      {{- include "loki.gatewaySelectorLabels" . | nindent 10 }}
+                  topologyKey: kubernetes.io/hostname
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 100
+                  podAffinityTerm:
+                    labelSelector:
+                      matchLabels:
+                        {{- include "loki.gatewaySelectorLabels" . | nindent 12 }}
+                    topologyKey: failure-domain.beta.kubernetes.io/zone
+        # -- Node selector for gateway pods
+        nodeSelector:
+          node: infra
+        # -- Tolerations for gateway pods
+        tolerations:
+        - effect: NoSchedule
+          key: node-role
+          operator: Equal
+          value: infra
+
+        # -- DNSConfig for gateway pods
+        dnsConfig: {}
+        # Gateway service configuration
+        service:
+            # -- Port of the gateway service
+            port: !!float 80
+            # -- Type of the gateway service
+            type: ClusterIP
+            # -- Load balancer allow traffic from CIDR list if service type is LoadBalancer
+            loadBalancerSourceRanges: []
+            # -- Annotations for the gateway service
+            annotations: {}
+            # -- Labels for gateway service
+            labels: {}
+        # Gateway ingress configuration
+        ingress:
+            # -- Specifies whether an ingress for the gateway should be created
+            enabled: false
+            # -- Ingress Class Name. MAY be required for Kubernetes versions >= 1.18
+            # For example: `ingressClassName: nginx`
+            ingressClassName: ""
+            # -- Annotations for the gateway ingress
+            annotations: {}
+            # -- Hosts configuration for the gateway ingress
+            hosts:
+                - host: gateway.loki.example.com
+                  paths:
+                    - path: /
+                      # -- pathType (e.g. ImplementationSpecific, Prefix, .. etc.) might also be required by some Ingress Controllers
+                      # pathType: Prefix
+            # -- TLS configuration for the gateway ingress
+            tls:
+                - secretName: loki-gateway-tls
+                  hosts:
+                    - gateway.loki.example.com
+        # Basic auth configuration
+        basicAuth:
+            # -- Enables basic authentication for the gateway
+            enabled: false
+            # -- Uses the specified username and password to compute a htpasswd using Sprig's `htpasswd` function.
+            # The value is templated using `tpl`. Override this to use a custom htpasswd, e.g. in case the default causes
+            # high CPU load.
+            # @default -- See values.yaml
+            htpasswd: >-
+                {{ htpasswd (required "'gateway.basicAuth.username' is required" .Values.gateway.basicAuth.username) (required "'gateway.basicAuth.password' is required" .Values.gateway.basicAuth.password) }}
+        # Configures the readiness probe for the gateway
+        readinessProbe:
+            httpGet:
+                path: /
+                port: http
+            initialDelaySeconds: !!float 15
+            timeoutSeconds: !!float 1
+        livenessProbe:
+            httpGet:
+                path: /
+                port: http
+            initialDelaySeconds: !!float 30
+        nginxConfig:
+            # -- NGINX log format
+            # @default -- See values.yaml
+            logFormat: |-
+                main '$remote_addr - $remote_user [$time_local]  $status '
+                        '"$request" $body_bytes_sent "$http_referer" '
+                        '"$http_user_agent" "$http_x_forwarded_for"';
+            # -- Allows appending custom configuration to the server block
+            serverSnippet: ""
+            # -- Allows appending custom configuration to the http block
+            httpSnippet: ""
+            # -- Allows overriding the DNS resolver address nginx will use.
+            resolver: ""
+            # -- Config file contents for Nginx. Passed through the `tpl` function to allow templating
+            # @default -- See values.yaml
+            file: |
+                worker_processes  5;  ## Default: 1
+                error_log  /dev/stderr;
+                pid        /tmp/nginx.pid;
+                worker_rlimit_nofile 8192;
+
+                events {
+                  worker_connections  4096;  ## Default: 1024
+                }
+
+                http {
+                  client_body_temp_path /tmp/client_temp;
+                  proxy_temp_path       /tmp/proxy_temp_path;
+                  fastcgi_temp_path     /tmp/fastcgi_temp;
+                  uwsgi_temp_path       /tmp/uwsgi_temp;
+                  scgi_temp_path        /tmp/scgi_temp;
+
+                  proxy_http_version    1.1;
+
+                  default_type application/octet-stream;
+                  log_format   {{ .Values.gateway.nginxConfig.logFormat }}
+
+                  {{- if .Values.gateway.verboseLogging }}
+                  access_log   /dev/stderr  main;
+                  {{- else }}
+
+                  map $status $loggable {
+                    ~^[23]  0;
+                    default 1;
+                  }
+                  access_log   /dev/stderr  main  if=$loggable;
+                  {{- end }}
+
+                  sendfile     on;
+                  tcp_nopush   on;
+                  {{- if .Values.gateway.nginxConfig.resolver }}
+                  resolver {{ .Values.gateway.nginxConfig.resolver }};
+                  {{- else }}
+                  resolver {{ .Values.global.dnsService }}.{{ .Values.global.dnsNamespace }}.svc.{{ .Values.global.clusterDomain }};
+                  {{- end }}
+
+                  {{- with .Values.gateway.nginxConfig.httpSnippet }}
+                  {{ . | nindent 2 }}
+                  {{- end }}
+
+                  server {
+                    listen             8080;
+
+                    {{- if .Values.gateway.basicAuth.enabled }}
+                    auth_basic           "Loki";
+                    auth_basic_user_file /etc/nginx/secrets/.htpasswd;
+                    {{- end }}
+
+                    location = / {
+                      return 200 'OK';
+                      auth_basic off;
+                    }
+
+                    location = /api/prom/push {
+                      set $api_prom_push_backend http://{{ include "loki.distributorFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+                      proxy_pass       $api_prom_push_backend:3100$request_uri;
+                      proxy_http_version 1.1;
+                    }
+
+                    location = /api/prom/tail {
+                      set $api_prom_tail_backend http://{{ include "loki.querierFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+                      proxy_pass       $api_prom_tail_backend:3100$request_uri;
+                      proxy_set_header Upgrade $http_upgrade;
+                      proxy_set_header Connection "upgrade";
+                      proxy_http_version 1.1;
+                    }
+
+                    # Ruler
+                    location ~ /prometheus/api/v1/alerts.* {
+                      proxy_pass       http://{{ include "loki.rulerFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+                    }
+                    location ~ /prometheus/api/v1/rules.* {
+                      proxy_pass       http://{{ include "loki.rulerFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+                    }
+                    location ~ /api/prom/rules.* {
+                      proxy_pass       http://{{ include "loki.rulerFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+                    }
+                    location ~ /api/prom/alerts.* {
+                      proxy_pass       http://{{ include "loki.rulerFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+                    }
+
+                    location ~ /api/prom/.* {
+                      set $api_prom_backend http://{{ include "loki.queryFrontendFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+                      proxy_pass       $api_prom_backend:3100$request_uri;
+                      proxy_http_version 1.1;
+                    }
+
+                    location = /loki/api/v1/push {
+                      set $loki_api_v1_push_backend http://{{ include "loki.distributorFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+                      proxy_pass       $loki_api_v1_push_backend:3100$request_uri;
+                      proxy_http_version 1.1;
+                    }
+
+                    location = /loki/api/v1/tail {
+                      set $loki_api_v1_tail_backend http://{{ include "loki.querierFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+                      proxy_pass       $loki_api_v1_tail_backend:3100$request_uri;
+                      proxy_set_header Upgrade $http_upgrade;
+                      proxy_set_header Connection "upgrade";
+                      proxy_http_version 1.1;
+                    }
+
+                    location ~ /loki/api/.* {
+                      set $loki_api_backend http://{{ include "loki.queryFrontendFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+                      proxy_pass       $loki_api_backend:3100$request_uri;
+                      proxy_http_version 1.1;
+                    }
+
+                    {{- with .Values.gateway.nginxConfig.serverSnippet }}
+                    {{ . | nindent 4 }}
+                    {{- end }}
+                  }
+                }
+    # Configuration for the compactor
+    compactor:
+        # -- Specifies whether compactor should be enabled
+        enabled: false
+        image: {}
+        # -- Labels for compactor pods
+        podLabels: {}
+        # -- Annotations for compactor pods
+        podAnnotations: {}
+        # -- Specify the compactor affinity
+        affinity: {}
+        # -- Labels for compactor service
+        serviceLabels: {}
+        # -- Additional CLI args for the compactor
+        extraArgs: []
+        # -- Environment variables to add to the compactor pods
+        extraEnv: []
+        # -- Environment variables from secrets or configmaps to add to the compactor pods
+        extraEnvFrom: []
+        # -- Volume mounts to add to the compactor pods
+        extraVolumeMounts: []
+        # -- Volumes to add to the compactor pods
+        extraVolumes: []
+        # -- Resource requests and limits for the compactor
+        resources: {}
+        # -- Containers to add to the compactor pods
+        extraContainers: []
+        # -- Init containers to add to the compactor pods
+        initContainers: []
+        # -- Grace period to allow the compactor to shutdown before it is killed
+        terminationGracePeriodSeconds: !!float 30
+        # -- Node selector for compactor pods
+        nodeSelector:
+          node: infra
+        # -- Tolerations for compactor pods
+        tolerations:
+        - effect: NoSchedule
+          key: node-role
+          operator: Equal
+          value: infra
+
+        persistence:
+            # -- Enable creating PVCs for the compactor
+            enabled: false
+            # -- Size of persistent disk
+            size: 10Gi
+        serviceAccount:
+            create: false
+            # -- Image pull secrets for the compactor service account
+            imagePullSecrets: []
+            # -- Annotations for the compactor service account
+            annotations: {}
+            # -- Set this toggle to false to opt out of automounting API credentials for the service account
+            automountServiceAccountToken: true
+    # Configuration for the ruler
+    ruler:
+        # -- Specifies whether the ruler should be enabled
+        enabled: false
+        # -- Kind of deployment [StatefulSet/Deployment]
+        kind: Deployment
+        # -- Number of replicas for the ruler
+        replicas: !!float 1
+        image: {}
+        # -- Labels for compactor pods
+        podLabels: {}
+        # -- Annotations for ruler pods
+        podAnnotations: {}
+        # -- Labels for ruler service
+        serviceLabels: {}
+        # -- Additional CLI args for the ruler
+        extraArgs: []
+        # -- Environment variables to add to the ruler pods
+        extraEnv: []
+        # -- Environment variables from secrets or configmaps to add to the ruler pods
+        extraEnvFrom: []
+        # -- Volume mounts to add to the ruler pods
+        extraVolumeMounts: []
+        # -- Volumes to add to the ruler pods
+        extraVolumes: []
+        # -- Resource requests and limits for the ruler
+        resources: {}
+        # -- Containers to add to the ruler pods
+        extraContainers: []
+        # -- Init containers to add to the ruler pods
+        initContainers: []
+        # -- Grace period to allow the ruler to shutdown before it is killed
+        terminationGracePeriodSeconds: !!float 300
+        # -- Affinity for ruler pods. Passed through `tpl` and, thus, to be configured as string
+        # @default -- Hard node and soft zone anti-affinity
+        affinity: |
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchLabels:
+                      {{- include "loki.rulerSelectorLabels" . | nindent 10 }}
+                  topologyKey: kubernetes.io/hostname
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 100
+                  podAffinityTerm:
+                    labelSelector:
+                      matchLabels:
+                        {{- include "loki.rulerSelectorLabels" . | nindent 12 }}
+                    topologyKey: failure-domain.beta.kubernetes.io/zone
+        # -- Node selector for ruler pods
+        nodeSelector:
+        node: role
+        # -- Tolerations for ruler pods
+        tolerations:
+        - effect: NoSchedule
+          key: node-role
+          operator: Equal
+          value: infra
+        # -- DNSConfig for ruler pods
+        dnsConfig: {}
+        persistence:
+            # -- Enable creating PVCs which is required when using recording rules
+            enabled: false
+            # -- Size of persistent disk
+            size: 10Gi
+        # -- Directories containing rules files
+        directories: {}
+        # tenant_foo:
+        #   rules1.txt: |
+        #     groups:
+        #       - name: should_fire
+        #         rules:
+        #           - alert: HighPercentageError
+        #             expr: |
+        #               sum(rate({app="foo", env="production"} |= "error" [5m])) by (job)
+        #                 /
+        #               sum(rate({app="foo", env="production"}[5m])) by (job)
+        #                 > 0.05
+        #             for: 10m
+        #             labels:
+        #               severity: warning
+        #             annotations:
+        #               summary: High error rate
+        #       - name: credentials_leak
+        #         rules:
+        #           - alert: http-credentials-leaked
+        #             annotations:
+        #               message: "{{ $labels.job }} is leaking http basic auth credentials."
+        #             expr: 'sum by (cluster, job, pod) (count_over_time({namespace="prod"} |~ "http(s?)://(\\w+):(\\w+)@" [5m]) > 0)'
+        #             for: 10m
+        #             labels:
+        #               severity: critical
+        #   rules2.txt: |
+        #     groups:
+        #       - name: example
+        #         rules:
+        #         - alert: HighThroughputLogStreams
+        #           expr: sum by(container) (rate({job=~"loki-dev/.*"}[1m])) > 1000
+        #           for: 2m
+        # tenant_bar:
+        #   rules1.txt: |
+        #     groups:
+        #       - name: should_fire
+        #         rules:
+        #           - alert: HighPercentageError
+        #             expr: |
+        #               sum(rate({app="foo", env="production"} |= "error" [5m])) by (job)
+        #                 /
+        #               sum(rate({app="foo", env="production"}[5m])) by (job)
+        #                 > 0.05
+        #             for: 10m
+        #             labels:
+        #               severity: warning
+        #             annotations:
+        #               summary: High error rate
+        #       - name: credentials_leak
+        #         rules:
+        #           - alert: http-credentials-leaked
+        #             annotations:
+        #               message: "{{ $labels.job }} is leaking http basic auth credentials."
+        #             expr: 'sum by (cluster, job, pod) (count_over_time({namespace="prod"} |~ "http(s?)://(\\w+):(\\w+)@" [5m]) > 0)'
+        #             for: 10m
+        #             labels:
+        #               severity: critical
+        #   rules2.txt: |
+        #     groups:
+        #       - name: example
+        #         rules:
+        #         - alert: HighThroughputLogStreams
+        #           expr: sum by(container) (rate({job=~"loki-dev/.*"}[1m])) > 1000
+        #           for: 2m
+    # Configuration for the index-gateway
+    indexGateway:
+        # -- Specifies whether the index-gateway should be enabled
+        enabled: false
+        # -- Number of replicas for the index-gateway
+        replicas: !!float 1
+        image: {}
+        # -- Labels for index-gateway pods
+        podLabels: {}
+        # -- Annotations for index-gateway pods
+        podAnnotations: {}
+        # -- Labels for index-gateway service
+        serviceLabels: {}
+        # -- Additional CLI args for the index-gateway
+        extraArgs: []
+        # -- Environment variables to add to the index-gateway pods
+        extraEnv: []
+        # -- Environment variables from secrets or configmaps to add to the index-gateway pods
+        extraEnvFrom: []
+        # -- Volume mounts to add to the index-gateway pods
+        extraVolumeMounts: []
+        # -- Volumes to add to the index-gateway pods
+        extraVolumes: []
+        # -- Resource requests and limits for the index-gateway
+        resources: {}
+        # -- Containers to add to the index-gateway pods
+        extraContainers: []
+        # -- Init containers to add to the index-gateway pods
+        initContainers: []
+        # -- Grace period to allow the index-gateway to shutdown before it is killed.
+        terminationGracePeriodSeconds: !!float 300
+        # -- Affinity for index-gateway pods. Passed through `tpl` and, thus, to be configured as string
+        # @default -- Hard node and soft zone anti-affinity
+        affinity: |
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchLabels:
+                      {{- include "loki.indexGatewaySelectorLabels" . | nindent 10 }}
+                  topologyKey: kubernetes.io/hostname
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 100
+                  podAffinityTerm:
+                    labelSelector:
+                      matchLabels:
+                        {{- include "loki.indexGatewaySelectorLabels" . | nindent 12 }}
+                    topologyKey: failure-domain.beta.kubernetes.io/zone
+        # -- Node selector for index-gateway pods
+        nodeSelector:
+          node: role
+        # -- Tolerations for index-gateway pods
+        tolerations:
+        - effect: NoSchedule
+          key: node-role
+          operator: Equal
+          value: infra
+
+        persistence:
+            # -- Enable creating PVCs which is required when using boltdb-shipper
+            enabled: false
+            # -- Use emptyDir with ramdisk for storage. **Please note that all data in indexGateway will be lost on pod restart**
+            inMemory: false
+            # -- Size of persistent or memory disk
+            size: 10Gi
+    memcached:
+        readinessProbe:
+            tcpSocket:
+                port: http
+            initialDelaySeconds: !!float 5
+            timeoutSeconds: !!float 1
+        livenessProbe:
+            tcpSocket:
+                port: http
+            initialDelaySeconds: !!float 10
+        image:
+            # -- The Docker registry for the memcached
+            registry: cr.yandex/yc-marketplace
+            # -- Memcached Docker image repository
+            repository: memcached1711787228740188845175192186348150321748355817562
+            # -- Memcached Docker image tag
+            tag: 1.6.7-alpine
+            # -- Memcached Docker image pull policy
+            pullPolicy: IfNotPresent
+        # -- Labels for memcached pods
+        podLabels: {}
+        # -- The SecurityContext for memcached pods
+        podSecurityContext:
+            fsGroup: !!float 11211
+            runAsGroup: !!float 11211
+            runAsNonRoot: true
+            runAsUser: !!float 11211
+        # -- The SecurityContext for memcached containers
+        containerSecurityContext:
+            readOnlyRootFilesystem: true
+            capabilities:
+                drop:
+                    - ALL
+            allowPrivilegeEscalation: false
+        # -- Common annotations for all memcached services
+        serviceAnnotations: {}
+        # -- Adds the appProtocol field to the memcached services. This allows memcached to work with istio protocol selection. Ex: "http" or "tcp"
+        appProtocol: ""
+    memcachedExporter:
+        # -- Specifies whether the Memcached Exporter should be enabled
+        enabled: false
+        image:
+            # -- The Docker registry for the Memcached Exporter
+            registry: cr.yandex/yc-marketplace
+            # -- Memcached Exporter Docker image repository
+            repository: prom/memcached-exporter1711787228740188845175192186348150321748355817562
+            # -- Memcached Exporter Docker image tag
+            tag: v0.6.0
+            # -- Memcached Exporter Docker image pull policy
+            pullPolicy: IfNotPresent
+        # -- Labels for memcached-exporter pods
+        podLabels: {}
+        # -- Memcached Exporter resource requests and limits
+        resources: {}
+        # -- The SecurityContext for memcachedExporter containers
+        containerSecurityContext:
+            readOnlyRootFilesystem: true
+            capabilities:
+                drop:
+                    - ALL
+            allowPrivilegeEscalation: false
+    memcachedChunks:
+        # -- Specifies whether the Memcached chunks cache should be enabled
+        enabled: false
+        # -- Number of replicas for memcached-chunks
+        replicas: !!float 1
+        # -- Labels for memcached-chunks pods
+        podLabels: {}
+        # -- Annotations for memcached-chunks pods
+        podAnnotations: {}
+        # -- Labels for memcached-chunks service
+        serviceLabels: {}
+        # -- Additional CLI args for memcached-chunks
+        extraArgs:
+            - -I 32m
+        # -- Environment variables to add to memcached-chunks pods
+        extraEnv: []
+        # -- Environment variables from secrets or configmaps to add to memcached-chunks pods
+        extraEnvFrom: []
+        # -- Resource requests and limits for memcached-chunks
+        resources: {}
+        # -- Containers to add to the memcached-chunks pods
+        extraContainers: []
+        # -- Grace period to allow memcached-chunks to shutdown before it is killed
+        terminationGracePeriodSeconds: !!float 30
+        # -- Affinity for memcached-chunks pods. Passed through `tpl` and, thus, to be configured as string
+        # @default -- Hard node and soft zone anti-affinity
+        affinity: |
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchLabels:
+                      {{- include "loki.memcachedChunksSelectorLabels" . | nindent 10 }}
+                  topologyKey: kubernetes.io/hostname
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 100
+                  podAffinityTerm:
+                    labelSelector:
+                      matchLabels:
+                        {{- include "loki.memcachedChunksSelectorLabels" . | nindent 12 }}
+                    topologyKey: failure-domain.beta.kubernetes.io/zone
+        # -- Node selector for memcached-chunks pods
+        nodeSelector:
+          node: infra
+        # -- Tolerations for memcached-chunks pods
+        tolerations:
+        - effect: NoSchedule
+          key: node-role
+          operator: Equal
+          value: infra
+
+    memcachedFrontend:
+        # -- Specifies whether the Memcached frontend cache should be enabled
+        enabled: false
+        # -- Number of replicas for memcached-frontend
+        replicas: !!float 1
+        # -- Labels for memcached-frontend pods
+        podLabels: {}
+        # -- Annotations for memcached-frontend pods
+        podAnnotations: {}
+        # -- Labels for memcached-frontend service
+        serviceLabels: {}
+        # -- Additional CLI args for memcached-frontend
+        extraArgs:
+            - -I 32m
+        # -- Environment variables to add to memcached-frontend pods
+        extraEnv: []
+        # -- Environment variables from secrets or configmaps to add to memcached-frontend pods
+        extraEnvFrom: []
+        # -- Resource requests and limits for memcached-frontend
+        resources: {}
+        # -- Containers to add to the memcached-frontend pods
+        extraContainers: []
+        # -- Grace period to allow memcached-frontend to shutdown before it is killed
+        terminationGracePeriodSeconds: !!float 30
+        # -- Affinity for memcached-frontend pods. Passed through `tpl` and, thus, to be configured as string
+        # @default -- Hard node and soft zone anti-affinity
+        affinity: |
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchLabels:
+                      {{- include "loki.memcachedFrontendSelectorLabels" . | nindent 10 }}
+                  topologyKey: kubernetes.io/hostname
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 100
+                  podAffinityTerm:
+                    labelSelector:
+                      matchLabels:
+                        {{- include "loki.memcachedFrontendSelectorLabels" . | nindent 12 }}
+                    topologyKey: failure-domain.beta.kubernetes.io/zone
+        # -- Pod Disruption Budget maxUnavailable
+        maxUnavailable: !!float 1
+        # -- Node selector for memcached-frontend pods
+        nodeSelector:
+          node: infra
+        # -- Tolerations for memcached-frontend pods
+        tolerations:
+        - effect: NoSchedule
+          key: node-role
+          operator: Equal
+          value: infra
+    memcachedIndexQueries:
+        # -- Specifies whether the Memcached index queries cache should be enabled
+        enabled: false
+        # -- Number of replicas for memcached-index-queries
+        replicas: !!float 1
+        # -- Labels for memcached-index-queries pods
+        podLabels: {}
+        # -- Annotations for memcached-index-queries pods
+        podAnnotations: {}
+        # -- Labels for memcached-index-queries service
+        serviceLabels: {}
+        # -- Additional CLI args for memcached-index-queries
+        extraArgs:
+            - -I 32m
+        # -- Environment variables to add to memcached-index-queries pods
+        extraEnv: []
+        # -- Environment variables from secrets or configmaps to add to memcached-index-queries pods
+        extraEnvFrom: []
+        # -- Resource requests and limits for memcached-index-queries
+        resources: {}
+        # -- Containers to add to the memcached-index-queries pods
+        extraContainers: []
+        # -- Grace period to allow memcached-index-queries to shutdown before it is killed
+        terminationGracePeriodSeconds: !!float 30
+        # -- Affinity for memcached-index-queries pods. Passed through `tpl` and, thus, to be configured as string
+        # @default -- Hard node and soft zone anti-affinity
+        affinity: |
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchLabels:
+                      {{- include "loki.memcachedIndexQueriesSelectorLabels" . | nindent 10 }}
+                  topologyKey: kubernetes.io/hostname
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 100
+                  podAffinityTerm:
+                    labelSelector:
+                      matchLabels:
+                        {{- include "loki.memcachedIndexQueriesSelectorLabels" . | nindent 12 }}
+                    topologyKey: failure-domain.beta.kubernetes.io/zone
+        # -- Node selector for memcached-index-queries pods
+        nodeSelector:
+          node: infra
+        # -- Tolerations for memcached-index-queries pods
+        tolerations:
+        - effect: NoSchedule
+          key: node-role
+          operator: Equal
+          value: infra
+    memcachedIndexWrites:
+        # -- Specifies whether the Memcached index writes cache should be enabled
+        enabled: false
+        # -- Number of replicas for memcached-index-writes
+        replicas: !!float 1
+        # -- Labels for memcached-index-writes pods
+        podLabels: {}
+        # -- Annotations for memcached-index-writes pods
+        podAnnotations: {}
+        # -- Labels for memcached-index-writes service
+        serviceLabels: {}
+        # -- Additional CLI args for memcached-index-writes
+        extraArgs:
+            - -I 32m
+        # -- Environment variables to add to memcached-index-writes pods
+        extraEnv: []
+        # -- Environment variables from secrets or configmaps to add to memcached-index-writes pods
+        extraEnvFrom: []
+        # -- Resource requests and limits for memcached-index-writes
+        resources: {}
+        # -- Containers to add to the memcached-index-writes pods
+        extraContainers: []
+        # -- Grace period to allow memcached-index-writes to shutdown before it is killed
+        terminationGracePeriodSeconds: !!float 30
+        # -- Affinity for memcached-index-writes pods. Passed through `tpl` and, thus, to be configured as string
+        # @default -- Hard node and soft zone anti-affinity
+        affinity: |
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchLabels:
+                      {{- include "loki.memcachedIndexWritesSelectorLabels" . | nindent 10 }}
+                  topologyKey: kubernetes.io/hostname
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 100
+                  podAffinityTerm:
+                    labelSelector:
+                      matchLabels:
+                        {{- include "loki.memcachedIndexWritesSelectorLabels" . | nindent 12 }}
+                    topologyKey: failure-domain.beta.kubernetes.io/zone
+        # -- Node selector for memcached-index-writes pods
+        nodeSelector:
+          node: infra
+        # -- Tolerations for memcached-index-writes pods
+        tolerations:
+        - effect: NoSchedule
+          key: node-role
+          operator: Equal
+          value: infra
+    networkPolicy:
+        # -- Specifies whether Network Policies should be created
+        enabled: false
+        metrics:
+            # -- Specifies the Pods which are allowed to access the metrics port.
+            # As this is cross-namespace communication, you also need the namespaceSelector.
+            podSelector: {}
+            # -- Specifies the namespaces which are allowed to access the metrics port
+            namespaceSelector: {}
+            # -- Specifies specific network CIDRs which are allowed to access the metrics port.
+            # In case you use namespaceSelector, you also have to specify your kubelet networks here.
+            # The metrics ports are also used for probes.
+            cidrs: []
+        ingress:
+            # -- Specifies the Pods which are allowed to access the http port.
+            # As this is cross-namespace communication, you also need the namespaceSelector.
+            podSelector: {}
+            # -- Specifies the namespaces which are allowed to access the http port
+            namespaceSelector: {}
+        alertmanager:
+            # -- Specify the alertmanager port used for alerting
+            port: !!float 9093
+            # -- Specifies the alertmanager Pods.
+            # As this is cross-namespace communication, you also need the namespaceSelector.
+            podSelector: {}
+            # -- Specifies the namespace the alertmanager is running in
+            namespaceSelector: {}
+        externalStorage:
+            # -- Specify the port used for external storage, e.g. AWS S3
+            ports: []
+            # -- Specifies specific network CIDRs you want to limit access to
+            cidrs: []
+        discovery:
+            # -- Specifies the Pods labels used for discovery.
+            # As this is cross-namespace communication, you also need the namespaceSelector.
+            podSelector: {}
+            # -- Specifies the namespace the discovery Pods are running in
+            namespaceSelector: {}

--- a/kubernetes-logging/screenshot
+++ b/kubernetes-logging/screenshot
@@ -1,0 +1,1 @@
+  Скриншот explore https://postimg.cc/q6y2dJt0/c4dd91f6

--- a/kubernetes-logging/taint_nodes
+++ b/kubernetes-logging/taint_nodes
@@ -1,0 +1,9 @@
+kubectl get node -o wide  --show-labels
+NAME                        STATUS   ROLES    AGE   VERSION   INTERNAL-IP   EXTERNAL-IP       OS-IMAGE             KERNEL-VERSION      CONTAINER-RUNTIME     LABELS
+cl1vmt8d77ghvdn8rr0v-ufar   Ready    <none>   40d   v1.26.2   10.128.0.6    178.154.228.243   Ubuntu 20.04.6 LTS   5.4.0-174-generic   containerd://1.6.28   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=standard-v3,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/zone=ru-central1-a,kubernetes.io/arch=amd64,kubernetes.io/hostname=cl1vmt8d77ghvdn8rr0v-ufar,kubernetes.io/os=linux,node.kubernetes.io/instance-type=standard-v3,node.kubernetes.io/kube-proxy-ds-ready=true,node.kubernetes.io/masq-agent-ds-ready=true,node.kubernetes.io/node-problem-detector-ds-ready=true,node=infra,topology.kubernetes.io/zone=ru-central1-a,yandex.cloud/node-group-id=cat4evjhsldqmd14nr3b,yandex.cloud/pci-topology=k8s,yandex.cloud/preemptible=false
+cl1vmt8d77ghvdn8rr0v-ujed   Ready    <none>   40d   v1.26.2   10.128.0.8    178.154.228.210   Ubuntu 20.04.6 LTS   5.4.0-174-generic   containerd://1.6.28   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=standard-v3,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/zone=ru-central1-a,kubernetes.io/arch=amd64,kubernetes.io/hostname=cl1vmt8d77ghvdn8rr0v-ujed,kubernetes.io/os=linux,node.kubernetes.io/instance-type=standard-v3,node.kubernetes.io/kube-proxy-ds-ready=true,node.kubernetes.io/masq-agent-ds-ready=true,node.kubernetes.io/node-problem-detector-ds-ready=true,topology.kubernetes.io/zone=ru-central1-a,yandex.cloud/node-group-id=cat4evjhsldqmd14nr3b,yandex.cloud/pci-topology=k8s,yandex.cloud/preemptible=false
+
+root@admin1:/home/admin1# kubectl get nodes -o custom-columns=NAME:.metadata.name,TAINTS:.spec.taints
+NAME                        TAINTS
+cl1vmt8d77ghvdn8rr0v-ufar   [map[effect:NoSchedule key:node-role value:infra]]
+cl1vmt8d77ghvdn8rr0v-ujed   <none>


### PR DESCRIPTION
# Выполнено ДЗ № 7 
Сервисы централизованного логирования для компонентов Kubernetes и приложений

 - [ ] Основное ДЗ
 4. Пошаговая инструкция
выполнения домашнего
задания
● Данное задание будет выполняться в managed k8s в Yandex cloud
● Разверните managed Kubernetes cluster в Yandex cloud любым
удобным вам способом
● Для кластера создайте 2 пула нод:
● Для рабочей нагрузки (можно 1 ноду)
● Для инфраструктурных сервисов (также хватит пока и 1
ноды)
● Для инфраструктурной ноды/нод добавьте taint, запрещающий на
нее планирование подов с посторонней нагрузкой -
node-role=infra:NoSchedule
● Приложите к ДЗ вывод комманд kubectl get node -o wide
--show-labels и kubectl get nodes -o
custom-columns=NAME:.metadata.name,TAINTS:.spec.taints
показывающий конфигурацию нод в вашем кластере
● Создайте бакет в s3 object storage Yandex cloud. В нем будут
храниться логи, собираемые loki. Также необходимо будет создать
ServiceAccount для доступа к бакету и сгенерировать ключи
доступа согласно инструкции YC
● Установите в кластер Loki
● монолитный или распределенный режим не принципиально
● Необходимо сконфигурировать параметры установки так,
чтобы компоненты loki устанавливались исключительно на
infra-ноды (добавить соответствующий toleration для обхода
taint, а также nodeSelector или nodeAffinity на ваш выбор, для
планирования подов только на заданные ноды)
● Место хранения логов – s3 бакет, ранее сконфигурированный
вами
● Auth_enabled: false
4. Пошаговая инструкция
выполнения домашнего
задания
● Установите в кластер promtail
● Агенты promtail должны быть развернуты на всех нодах
кластера, включая infra-ноды (добавить toleration)
● Установите в кластер Grafana
● Должна быть установлена на infra-ноды (toleration и
nodeSelector/NodeAffinity)
● Для установленных loki, promtail и Grafana приложить к ДЗ файлы
values.yaml, которые вы использовали для установки, а также
команду установки и репозиторий, из которого ставили, если
требуется. Не обязательно устанавливать все 3 компонента из
разных чартов, приложите именно тот способ установки, который
вы использовали.
● В Grafana необходимо настроить data source к loki и сделать explore
по этому datasource и убедиться, что логи отображаются.
Приложить скриншот этого экрана из Grafana
● Если будете ставить loki из чарта, который предлагает Yandex
(там достаточно старый loki) – последние версии графаны
могут не заработать с ним, необходимо будет явно
установить какую-то из старых версий (например 8.5.28)
 - [ ] Задание со *

## В процессе сделано:
 - Пункт 1  создан кластер кубернетес в yandex.cloud  с 2 нодами  у одной из нод установлен label node=infra и taint 
 node-role=infra:NoSchedule
 
 - Пункт 2
 создан  s3 storage  и sa  к нему далее к нему создан ключ 
 - Пункт 3
 helm pull oci://cr.yandex/yc-marketplace/yandex-cloud/grafana/loki/chart/loki \
  --version 1.1.2 \
  --untar && \
внесение правок в values.yaml  Добавление nodeSelector и tolerations  

пункт 4 
helm install loki \
  --namespace monitoring \
  --create-namespace \
  --set loki-distributed.loki.storageConfig.aws.bucketnames=<имя_бакета_Object_Storage> \
  --set loki-distributed.serviceaccountawskeyvalue_generated.accessKeyID=<идентификатор_ключа_сервисного_аккаунта> \
  --set loki-distributed.serviceaccountawskeyvalue_generated.secretAccessKey=<секретный_ключ_сервисного_аккаунта> \
  loki ./loki/


пункт 5 helm search  repo grafana (ищем  подходящую  grafana)
helm pull lgtm-distributed 
вытаскиваем отсюда grafanu из charts   меняем tag c "" на 8.5.3 
 раскоменчиваем datasourses 
datasources:
  datasources.yaml:
    apiVersion: 1
    datasources:
    - name: Loki
      type: loki
      url: http://loki-loki-distributed-gateway.monitoring.svc
      access: proxy
      jsonData:
        timeout: 60
        maxLines: 1000


## Как запустить проект:
 - Например, запустить команду X в директории Y

kubectl --namespace monitoring port-forward  ($name_pod_grafana) 3000
в  explore  проверяем логи


## Как проверить работоспособность:
 - Например, перейти по ссылке http://localhost:8080
http://localhost:3000
проверяем что  datasourses http://loki-loki-distributed-gateway.monitoring.svc   щлет данные с 2 нод 


## PR checklist:
 - [ ] Выставлен label с темой домашнего задания
