### PR TITLE
Kubernetes prod

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,182 @@
 # Репозиторий для выполнения домашних заданий курса "Инфраструктурная платформа на основе Kubernetes-2024-02" 
+
+создаем машины в облаке яндекс 
+Ниже команды нужно воспроизвести на всех нодах кластера  на worker  на master 
+ sudo apt-get install -y apt-transport-https ca-certificates curl gpg  устанавливаем доп пакеты 
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.29/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg   ключи для репы
+ echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.29/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list  адрес репы 
+ sudo apt-get update обновляем пакеты после добавление репы
+ sudo apt-get install -y kubelet kubeadm kubectl  устанавливаем  по   для кубера 
+sudo systemctl enable --now kubelet  выключаем автообновление сервисов кубера 
+sudo swapoff -a отключаем свап 
+ wget https://github.com/containerd/containerd/releases/download/v1.6.8/containerd-1.6.8-linux-amd64.tar.gz   устанавливаем cri 
+ sudo tar Cxzvf /usr/local containerd-1.6.8-linux-amd64.tar.gz
+wget https://github.com/opencontainers/runc/releases/download/v1.1.3/runc.amd64 
+ sudo install -m 755 runc.amd64 /usr/local/sbin/runc
+ wget https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-amd64-v1.1.1.tgz
+sudo mkdir -p /opt/cni/bin
+sudo tar Cxzvf /opt/cni/bin cni-plugins-linux-amd64-v1.1.1.tgz
+ sudo mkdir /etc/containerd
+ containerd config default | sudo tee /etc/containerd/config.toml
+sudo sed -i 's/SystemdCgroup \= false/SystemdCgroup \= true/g' /etc/containerd/config.toml   включаем cgroup
+ sudo curl -L https://raw.githubusercontent.com/containerd/containerd/main/containerd.service -o /etc/systemd/system/containerd.service
+ sudo systemctl daemon-reload
+sudo systemctl enable --now containerd
+
+cat <<EOF | sudo tee /etc/modules-load.d/k8s.conf
+overlay
+br_netfilter
+EOF  смотрим значение 
+sudo modprobe overlay
+sudo modprobe br_netfilter
+cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
+net.bridge.bridge-nf-call-iptables  = 1
+net.bridge.bridge-nf-call-ip6tables = 1
+net.ipv4.ip_forward                 = 1
+EOF   вносим изменения 
+
+sudo sysctl --system
+lsmod | grep br_netfilter
+lsmod | grep overlay
+sysctl net.bridge.bridge-nf-call-iptables net.bridge.bridge-nf-call-ip6tables net.ipv4.ip_forward
+
+Далее на мастере делаем  
+kubeadm init --pod-network-cidr=10.244.0.0/16   иницируем создание кластера 
+копируем   куб конфиг 
+mkdir -p $HOME/.kube
+sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
+sudo chown $(id -u):$(id -g) $HOME/.kube/config
+kubectl apply -f https://github.com/coreos/flannel/raw/master/Documentation/kube-flannel.yml    устанавливаем сетевой плагин   
+
+На worker   node
+ kubeadm join 10.128.0.24:6443 --token qxmls9.eg8zayjgmr1d9fti \
+        --discovery-token-ca-cert-hash sha256:514478ce11e3b57e8438664df1690fb77d51d49d634576d64b6f3d3a1b3e7f23
+
+
+
+
+Для обновление мастера  в кластере 
+
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list  добавляем репу 
+sudo apt update
+ sudo apt-cache madison kubeadm  смотрим какие есть версии 
+sudo apt-mark unhold kubeadm && sudo apt-get update && sudo apt-get install -y kubeadm='1.30.0-1.1' && sudo apt-mark hold kubeadm   устанавливаем  kubeadm
+ kubeadm version проверяем  версию 
+sudo kubeadm upgrade plan   смотрим план по обновлению
+sudo kubeadm upgrade apply v1.30.0  обновляем  kubeadm
+sudo apt-mark unhold kubelet kubectl && sudo apt-get update && sudo apt-get install -y kubelet='1.30.0-1.1' kubectl='1.30.0-1.1' && sudo apt-mark hold kubelet kubectl  устанавливаем  kubelet  и kubectl 
+sudo systemctl daemon-reload    обновляем демона
+sudo systemctl restart kubelet  рестартим кубелет 
+
+Команды делаем на мастере 
+для вывода ноды и последующего ее обновления 
+kubectl drain  $node_name --ignore-daemonsets  снимаем нагрузку 
+после обновления 
+kubectl uncordon $node_name
+
+
+на воркере  аналогично мастеру 
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+sudo apt update
+ sudo apt-cache madison kubeadm
+sudo apt-mark unhold kubeadm && sudo apt-get update && sudo apt-get install -y kubeadm='1.30.0-1.1' && sudo apt-mark hold kubeadm
+kubeadm version
+sudo kubeadm upgrade node
+sudo apt-mark unhold kubelet kubectl && sudo apt-get update && sudo apt-get install -y kubelet='1.30.0-1.1' kubectl='1.30.0-1.1' && sudo apt-mark hold kubelet kubectl
+sudo systemctl daemon-reload
+sudo systemctl restart kubelet
+
+
+
+Для установки через  kubespray
+создаем пользователя  на всех  в кластере 
+sudo useradd -m -d /home/testuser -s /bin/bash testuser
+sudo su - testuser
+mkdir .ssh
+touch .ssh/authorized_keys
+echo "<публичный_ключ>" >> /home/testuser/.ssh/authorized_keys
+chmod 700 ~/.ssh
+chmod 600 ~/.ssh/authorized_keys
+
+
+
+на админсмкую тачку устанавливаем  ansible 
+apt-get install ansible
+apt-get install pip 
+git clone   https://github.com/kubernetes-sigs/kubespray.git 
+
+VENVDIR=kubespray-venv
+KUBESPRAYDIR=kubespray
+python3 -m venv $VENVDIR
+source $VENVDIR/bin/activate
+cd $KUBESPRAYDIR
+pip install -U -r requirements.txt   --break-system-packages устанавливаем зависиомсти 
+копируем рыбу примера инвенторя cp -rfp inventory/sample inventory/mycluster 
+
+declare -a IPS=(10.10.1.3 10.10.1.4 10.10.1.5)   вписываем  айпи адреса своих  машин 
+CONFIG_FILE=inventory/mycluster/hosts.yaml python3 contrib/inventory_builder/inventory.py ${IPS[@]} 
+правим инветори фаил   (node  заменяем названием   hostname машин   ставим своего ansible_user)   
+all:
+  vars:
+    ansible_user: kuber
+    ansible_python_interpreter: /usr/bin/python3
+    become: true
+  hosts:
+    node1:
+      ansible_host: 10.128.0.28
+      ip: 10.128.0.28
+      access_ip: 10.128.0.28
+    node2:
+      ansible_host: 10.128.0.30
+      ip: 10.128.0.30
+      access_ip: 10.128.0.30
+    node3:
+      ansible_host: 10.128.0.19
+      ip: 10.128.0.19
+      access_ip: 10.128.0.19
+    node4:
+      ansible_host: 10.128.0.9
+      ip: 10.128.0.9
+      access_ip: 10.128.0.9
+    node5:
+      ansible_host: 10.128.0.39
+      ip: 10.128.0.39
+      access_ip: 10.128.0.39
+  children:
+    kube_control_plane:
+      hosts:
+        node1:
+        node2:
+        node3:
+    kube_node:
+      hosts:
+        node4:
+        node5:
+    etcd:
+      hosts:
+        node1:
+        node2:
+        node3:
+    k8s_cluster:
+      children:
+        kube_control_plane:
+        kube_node:
+    calico_rr:
+      hosts: {}
+
+
+далее выполняем плейбук
+
+ansible-playbook -i inventory/mycluster/hosts.yaml  -b cluster.yml
+
+
+
+
+
+
+
+
+
+
+
+

--- a/kubernetes-prod/inventory_kuberspray
+++ b/kubernetes-prod/inventory_kuberspray
@@ -1,0 +1,47 @@
+all:
+  vars:
+    ansible_user: kuber
+    ansible_python_interpreter: /usr/bin/python3
+    become: true
+  hosts:
+    node1:
+      ansible_host: 10.128.0.28
+      ip: 10.128.0.28
+      access_ip: 10.128.0.28
+    node2:
+      ansible_host: 10.128.0.30
+      ip: 10.128.0.30
+      access_ip: 10.128.0.30
+    node3:
+      ansible_host: 10.128.0.19
+      ip: 10.128.0.19
+      access_ip: 10.128.0.19
+    node4:
+      ansible_host: 10.128.0.9
+      ip: 10.128.0.9
+      access_ip: 10.128.0.9
+    node5:
+      ansible_host: 10.128.0.39
+      ip: 10.128.0.39
+      access_ip: 10.128.0.39
+  children:
+    kube_control_plane:
+      hosts:
+        node1:
+        node2:
+        node3:
+    kube_node:
+      hosts:
+        node4:
+        node5:
+    etcd:
+      hosts:
+        node1:
+        node2:
+        node3:
+    k8s_cluster:
+      children:
+        kube_control_plane:
+        kube_node:
+    calico_rr:
+      hosts: {}

--- a/kubernetes-prod/kuberspray_information_node
+++ b/kubernetes-prod/kuberspray_information_node
@@ -1,0 +1,10 @@
+root@master-1:/home/admin# kubectl get nodes -o wide
+NAME    STATUS   ROLES           AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE           KERNEL-VERSION     CONTAINER-RUNTIME
+node1   Ready    control-plane   17m   v1.29.5   10.128.0.28   <none>        Ubuntu 24.04 LTS   6.8.0-35-generic   containerd://1.7.16
+node2   Ready    control-plane   16m   v1.29.5   10.128.0.30   <none>        Ubuntu 24.04 LTS   6.8.0-35-generic   containerd://1.7.16
+node3   Ready    control-plane   16m   v1.29.5   10.128.0.19   <none>        Ubuntu 24.04 LTS   6.8.0-35-generic   containerd://1.7.16
+node4   Ready    <none>          15m   v1.29.5   10.128.0.9    <none>        Ubuntu 24.04 LTS   6.8.0-35-generic   containerd://1.7.16
+node5   Ready    <none>          15m   v1.29.5   10.128.0.39   <none>        Ubuntu 24.04 LTS   6.8.0-35-generic   containerd://1.7.16
+
+
+

--- a/kubernetes-prod/node_information
+++ b/kubernetes-prod/node_information
@@ -1,0 +1,6 @@
+root@master:/home/admin# kubectl get nodes -o wide
+NAME       STATUS   ROLES           AGE     VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE           KERNEL-VERSION     CONTAINER-RUNTIME
+master     Ready    control-plane   4h35m   v1.29.6   10.128.0.24   <none>        Ubuntu 24.04 LTS   6.8.0-35-generic   containerd://1.6.8
+worker-1   Ready    <none>          4h31m   v1.29.6   10.128.0.37   <none>        Ubuntu 24.04 LTS   6.8.0-35-generic   containerd://1.6.8
+worker-2   Ready    <none>          4h31m   v1.29.6   10.128.0.25   <none>        Ubuntu 24.04 LTS   6.8.0-35-generic   containerd://1.6.8
+worker-3   Ready    <none>          3h10m   v1.29.6   10.128.0.17   <none>        Ubuntu 24.04 LTS   6.8.0-35-generic   containerd://1.6.8

--- a/kubernetes-prod/readme_node_master
+++ b/kubernetes-prod/readme_node_master
@@ -1,0 +1,46 @@
+ sudo apt-get install -y apt-transport-https ca-certificates curl gpg  устанавливаем доп пакеты 
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.29/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg   ключи для репы
+ echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.29/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list  адрес репы 
+ sudo apt-get update обновляем пакеты после добавление репы
+ sudo apt-get install -y kubelet kubeadm kubectl  устанавливаем  по   для кубера 
+sudo systemctl enable --now kubelet  выключаем автообновление сервисов кубера 
+sudo swapoff -a отключаем свап 
+ wget https://github.com/containerd/containerd/releases/download/v1.6.8/containerd-1.6.8-linux-amd64.tar.gz   устанавливаем cri 
+ sudo tar Cxzvf /usr/local containerd-1.6.8-linux-amd64.tar.gz
+wget https://github.com/opencontainers/runc/releases/download/v1.1.3/runc.amd64 
+ sudo install -m 755 runc.amd64 /usr/local/sbin/runc
+ wget https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-amd64-v1.1.1.tgz
+sudo mkdir -p /opt/cni/bin
+sudo tar Cxzvf /opt/cni/bin cni-plugins-linux-amd64-v1.1.1.tgz
+ sudo mkdir /etc/containerd
+ containerd config default | sudo tee /etc/containerd/config.toml
+sudo sed -i 's/SystemdCgroup \= false/SystemdCgroup \= true/g' /etc/containerd/config.toml   включаем cgroup
+ sudo curl -L https://raw.githubusercontent.com/containerd/containerd/main/containerd.service -o /etc/systemd/system/containerd.service
+ sudo systemctl daemon-reload
+sudo systemctl enable --now containerd
+
+cat <<EOF | sudo tee /etc/modules-load.d/k8s.conf
+overlay
+br_netfilter
+EOF  смотрим значение 
+sudo modprobe overlay
+sudo modprobe br_netfilter
+cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
+net.bridge.bridge-nf-call-iptables  = 1
+net.bridge.bridge-nf-call-ip6tables = 1
+net.ipv4.ip_forward                 = 1
+EOF   вносим изменения 
+
+sudo sysctl --system
+lsmod | grep br_netfilter
+lsmod | grep overlay
+sysctl net.bridge.bridge-nf-call-iptables net.bridge.bridge-nf-call-ip6tables net.ipv4.ip_forward
+kubeadm init --pod-network-cidr=10.244.0.0/16   иницируем создание кластера 
+
+
+mkdir -p $HOME/.kube
+sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
+sudo chown $(id -u):$(id -g) $HOME/.kube/config
+
+
+kubectl apply -f https://github.com/coreos/flannel/raw/master/Documentation/kube-flannel.yml    устанавливаем сетевой плагин   

--- a/kubernetes-prod/readme_node_worker
+++ b/kubernetes-prod/readme_node_worker
@@ -1,0 +1,44 @@
+ sudo apt-get install -y apt-transport-https ca-certificates curl gpg  устанавливаем доп пакеты 
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.29/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg   ключи для репы
+ echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.29/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list  адрес репы 
+ sudo apt-get update обновляем пакеты после добавление репы
+ sudo apt-get install -y kubelet kubeadm kubectl  устанавливаем  по   для кубера 
+sudo systemctl enable --now kubelet  выключаем автообновление сервисов кубера 
+sudo swapoff -a отключаем свап 
+ wget https://github.com/containerd/containerd/releases/download/v1.6.8/containerd-1.6.8-linux-amd64.tar.gz   устанавливаем cri 
+ sudo tar Cxzvf /usr/local containerd-1.6.8-linux-amd64.tar.gz
+wget https://github.com/opencontainers/runc/releases/download/v1.1.3/runc.amd64 
+ sudo install -m 755 runc.amd64 /usr/local/sbin/runc
+ wget https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-amd64-v1.1.1.tgz
+sudo mkdir -p /opt/cni/bin
+sudo tar Cxzvf /opt/cni/bin cni-plugins-linux-amd64-v1.1.1.tgz
+ sudo mkdir /etc/containerd
+ containerd config default | sudo tee /etc/containerd/config.toml
+sudo sed -i 's/SystemdCgroup \= false/SystemdCgroup \= true/g' /etc/containerd/config.toml   включаем cgroup
+ sudo curl -L https://raw.githubusercontent.com/containerd/containerd/main/containerd.service -o /etc/systemd/system/containerd.service
+ sudo systemctl daemon-reload
+sudo systemctl enable --now containerd
+
+cat <<EOF | sudo tee /etc/modules-load.d/k8s.conf
+overlay
+br_netfilter
+EOF  смотрим значение 
+sudo modprobe overlay
+sudo modprobe br_netfilter
+cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
+net.bridge.bridge-nf-call-iptables  = 1
+net.bridge.bridge-nf-call-ip6tables = 1
+net.ipv4.ip_forward                 = 1
+EOF   вносим изменения 
+
+sudo sysctl --system
+lsmod | grep br_netfilter
+lsmod | grep overlay
+sysctl net.bridge.bridge-nf-call-iptables net.bridge.bridge-nf-call-ip6tables net.ipv4.ip_forward
+после инициализации мастера мы получаем команду,  с помощью него добавляем ноду в кластер
+пример:
+# kubeadm join 10.128.0.24:6443 --token qxmls9.eg8zayjgmr1d9fti \
+        --discovery-token-ca-cert-hash sha256:514478ce11e3b57e8438664df1690fb77d51d49d634576d64b6f3d3a1b3e7f23
+
+
+

--- a/kubernetes-prod/updrage_node_command
+++ b/kubernetes-prod/updrage_node_command
@@ -1,0 +1,21 @@
+на мастере 
+kubectl drain  $node_name --ignore-daemonsets  снимаем нагрузку 
+
+
+на воркере 
+изменяем репу  на нужную версию 
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+sudo apt update
+ sudo apt-cache madison kubeadm
+sudo apt-mark unhold kubeadm && sudo apt-get update && sudo apt-get install -y kubeadm='1.30.0-1.1' && sudo apt-mark hold kubeadm
+kubeadm version
+sudo kubeadm upgrade node
+sudo apt-mark unhold kubelet kubectl && sudo apt-get update && sudo apt-get install -y kubelet='1.30.0-1.1' kubectl='1.30.0-1.1' && sudo apt-mark hold kubelet kubectl
+sudo systemctl daemon-reload
+sudo systemctl restart kubelet
+
+
+
+
+на мастере 
+kubectl uncordon $node_name

--- a/kubernetes-prod/upgrade_master_node
+++ b/kubernetes-prod/upgrade_master_node
@@ -1,0 +1,10 @@
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+sudo apt update
+ sudo apt-cache madison kubeadm
+sudo apt-mark unhold kubeadm && sudo apt-get update && sudo apt-get install -y kubeadm='1.30.0-1.1' && sudo apt-mark hold kubeadm
+ kubeadm version
+sudo kubeadm upgrade plan
+sudo kubeadm upgrade apply v1.30.0
+sudo apt-mark unhold kubelet kubectl && sudo apt-get update && sudo apt-get install -y kubelet='1.30.x-*' kubectl='1.30.x-*' && sudo apt-mark hold kubelet kubectl
+sudo systemctl daemon-reload
+sudo systemctl restart kubelet

--- a/kubernetes-prod/upgrade_node_information
+++ b/kubernetes-prod/upgrade_node_information
@@ -1,0 +1,6 @@
+root@master:/home/admin# kubectl get  nodes -o wide
+NAME       STATUS   ROLES           AGE     VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE           KERNEL-VERSION     CONTAINER-RUNTIME
+master     Ready    control-plane   4h46m   v1.30.0   10.128.0.25   <none>        Ubuntu 24.04 LTS   6.8.0-35-generic   containerd://1.6.8
+worker-1   Ready    <none>          47m     v1.30.0   10.128.0.18   <none>        Ubuntu 24.04 LTS   6.8.0-35-generic   containerd://1.6.8
+worker-2   Ready    <none>          47m     v1.30.0   10.128.0.15   <none>        Ubuntu 24.04 LTS   6.8.0-35-generic   containerd://1.6.8
+worker-3   Ready    <none>          47m     v1.30.0   10.128.0.20   <none>        Ubuntu 24.04 LTS   6.8.0-35-generic   containerd://1.6.8


### PR DESCRIPTION
# Выполнено ДЗ №14

 - [ ] Основное ДЗ
Для выполнения данного задания вам потребуется создать
минимум 4 виртуальных машины в YC следующей конфигурации:
● Для master - 1 узел, 2vCPU, 8GB RAM
● Для worker – 3 узла, 2vCPU, 8GB RAM
● Версия создаваемого кластера должна быть на одну ниже чем
актуальная версия kubernetes на момент выполнения (т.е если
последняя актуальная версия 1.30.x, то ставим 1.29.x)
● Выполните подготовительные работы на узлах в соответствии с
инструкцией (отключить swap, включите маршрутизацию и т.д)
● Установите containerd, kubeadm, kubelet, kubectl на все ВМ
● Выполните kubeadm init на мастер-ноде
● Установите Flannel в качестве сетевого плагина
● Выполните kubeadm join на воркер нодах
● Приложите к результатам ДЗ вывод команды kubectl get nodes -o
wide, показывающий статус и версию k8s всех нод кластера
● Приложите к результатам ДЗ все команды, выполненные вами как
на мастер, так и на воркер нодах (можно в readme, можно в виде .sh
скриптов, или иным образом как вам удобно) для возможности
воспроизведения ваших действий
● Выполните обновление master ноды до последней актуальной
версии k8s с помощью kubeadm
● Последовательно выведите из планирования все воркер-ноды,
обновите их до последней актуальной версии и верните в
планирование
● Приложите к результатам ДЗ все команды по обновлению версии
кластера, аналогично как вы делали это для команд установки
● Приложите к результатам ДЗ вывод команды kubectl get nodes -o
wide, показывающий статус и версию k8s всех нод кластера после
обновлени
 - [ ] Задание со *

● Создайте минимум 5 нод следующей конфигурации:
● Для master - 3 узла, 2vCPU, 8GB RAM
● Для worker – минимум 2 узла, 2vCPU, 8GB RAM
● Разверните отказоустойчивый кластер K8s с помощью kubespray
(3 master ноды, минимум 2 worker)
● К результатам ДЗ приложите inventory файл который вы
использовали для создания кластера и вывод команды kubectl get
nodes –o wide
## В процессе сделано:
 - Пункт 1
 Для выполнения данного задания вам потребуется создать
минимум 4 виртуальных машины в YC следующей конфигурации:
● Для master - 1 узел, 2vCPU, 8GB RAM
● Для worker – 3 узла, 2vCPU, 8GB RAM
Done
- Пункт 2
Версия создаваемого кластера должна быть на одну ниже чем
актуальная версия kubernetes на момент выполнения (т.е если
последняя актуальная версия 1.30.x, то ставим 1.29.x)
использовалась версия 1.29.6
- Пункт 3
Выполните подготовительные работы на узлах в соответствии с
инструкцией (отключить swap, включите маршрутизацию и т.д)
sudo swapoff -a
cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
net.bridge.bridge-nf-call-iptables  = 1
net.bridge.bridge-nf-call-ip6tables = 1
net.ipv4.ip_forward                 = 1
EOF
- Пункт 4
Установите containerd, kubeadm, kubelet, kubectl на все ВМ
sudo curl -L https://raw.githubusercontent.com/containerd/containerd/main/containerd.service -o /etc/systemd/system/containerd.service
 sudo systemctl daemon-reload
sudo systemctl enable --now containerd
 echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.29/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list  
 sudo apt-get update о
 sudo apt-get install -y kubelet kubeadm kubectl 
Пункт 6
Выполните kubeadm init на мастер-ноде
kubeadm init --pod-network-cidr=10.244.0.0/16
Пункт 7
Установите Flannel в качестве сетевого плагина
kubectl apply -f https://github.com/coreos/flannel/raw/master/Documentation/kube-flannel.yml
Пункт 8
Выполните обновление master ноды до последней актуальной
версии k8s с помощью kubeadm
echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
sudo apt update
 sudo apt-cache madison kubeadm
sudo apt-mark unhold kubeadm && sudo apt-get update && sudo apt-get install -y kubeadm='1.30.0-1.1' && sudo apt-mark hold kubeadm
 kubeadm version
sudo kubeadm upgrade plan
sudo kubeadm upgrade apply v1.30.0
sudo apt-mark unhold kubelet kubectl && sudo apt-get update && sudo apt-get install -y kubelet='1.30.x-*' kubectl='1.30.x-*' && sudo apt-mark hold kubelet kubectl
sudo systemctl daemon-reload
sudo systemctl restart kubelet
Пункт 9
Последовательно выведите из планирования все воркер-ноды,
обновите их до последней актуальной версии и верните в
планирование
echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
sudo apt update
 sudo apt-cache madison kubeadm
sudo apt-mark unhold kubeadm && sudo apt-get update && sudo apt-get install -y kubeadm='1.30.0-1.1' && sudo apt-mark hold kubeadm
kubeadm version
sudo kubeadm upgrade node
sudo apt-mark unhold kubelet kubectl && sudo apt-get update && sudo apt-get install -y kubelet='1.30.0-1.1' kubectl='1.30.0-1.1' && sudo apt-mark hold kubelet kubectl
sudo systemctl daemon-reload
sudo systemctl restart kubelet
Пункт* 
git clone https://github.com/kubernetes-sigs/kubespray.git 
apt-get install ansible 
VENVDIR=kubespray-venv
KUBESPRAYDIR=kubespray
python3 -m venv $VENVDIR
source $VENVDIR/bin/activate
cd $KUBESPRAYDIR
pip install -U -r requirements.txt
cp -rfp inventory/sample inventory/mycluster
declare -a IPS=(10.10.1.3 10.10.1.4 10.10.1.5)  выставляем айпи адреса наших вм
CONFIG_FILE=inventory/mycluster/hosts.yaml python3 contrib/inventory_builder/inventory.py ${IPS[@]}
ansible-playbook -i inventory/mycluster/hosts.yaml  -b cluster.yml -kK
добавил ansible_user  в  инвентори 
создал отдельного  user   kuber    на машинах  и прокинул ключи 





 Как проверить работоспособность:
 kubectl get nodes -A 


